### PR TITLE
feat: Add Project Unification, Library, and Design Packs (Issue #20)

### DIFF
--- a/src-tauri/src/commands/design_pack_storage.rs
+++ b/src-tauri/src/commands/design_pack_storage.rs
@@ -1,0 +1,154 @@
+use serde_json::Value;
+use std::path::PathBuf;
+use tokio::fs;
+
+const DESIGN_PACKS_DIR: &str = "design-packs";
+const INDEX_FILE: &str = "packs.json";
+
+// Helper to get the design packs directory
+fn get_packs_dir(app_handle: &tauri::AppHandle) -> Result<PathBuf, String> {
+    let app_data_dir = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data directory: {}", e))?;
+    Ok(app_data_dir.join(DESIGN_PACKS_DIR))
+}
+
+// Helper to get the index file path
+fn get_index_path(app_handle: &tauri::AppHandle) -> Result<PathBuf, String> {
+    Ok(get_packs_dir(app_handle)?.join(INDEX_FILE))
+}
+
+// ============================================
+// Design Pack Commands
+// ============================================
+
+/// Get all design packs
+#[tauri::command]
+pub async fn get_design_packs(app_handle: tauri::AppHandle) -> Result<String, String> {
+    let index_path = get_index_path(&app_handle)?;
+
+    // If file doesn't exist, return empty array
+    if !index_path.exists() {
+        return Ok("[]".to_string());
+    }
+
+    fs::read_to_string(&index_path)
+        .await
+        .map_err(|e| format!("Failed to read design packs: {}", e))
+}
+
+/// Get a specific design pack by ID
+#[tauri::command]
+pub async fn get_design_pack(
+    app_handle: tauri::AppHandle,
+    pack_id: String,
+) -> Result<String, String> {
+    let index_path = get_index_path(&app_handle)?;
+
+    if !index_path.exists() {
+        return Err(format!("Design pack not found: {}", pack_id));
+    }
+
+    let content = fs::read_to_string(&index_path)
+        .await
+        .map_err(|e| format!("Failed to read design packs: {}", e))?;
+
+    let packs: Vec<Value> = serde_json::from_str(&content).unwrap_or_else(|_| Vec::new());
+
+    for pack in packs {
+        if pack.get("packId").and_then(|v| v.as_str()) == Some(&pack_id) {
+            return serde_json::to_string(&pack)
+                .map_err(|e| format!("Failed to serialize pack: {}", e));
+        }
+    }
+
+    Err(format!("Design pack not found: {}", pack_id))
+}
+
+/// Save a design pack (create or update)
+#[tauri::command]
+pub async fn save_design_pack(
+    app_handle: tauri::AppHandle,
+    pack: String,
+) -> Result<(), String> {
+    let packs_dir = get_packs_dir(&app_handle)?;
+    let index_path = get_index_path(&app_handle)?;
+
+    // Create directory if it doesn't exist
+    fs::create_dir_all(&packs_dir)
+        .await
+        .map_err(|e| format!("Failed to create design packs directory: {}", e))?;
+
+    // Parse the incoming pack
+    let new_pack: Value =
+        serde_json::from_str(&pack).map_err(|e| format!("Invalid pack JSON: {}", e))?;
+
+    let pack_id = new_pack
+        .get("packId")
+        .and_then(|v| v.as_str())
+        .ok_or("Pack must have a packId")?;
+
+    // Read existing packs
+    let mut packs: Vec<Value> = if index_path.exists() {
+        let content = fs::read_to_string(&index_path)
+            .await
+            .map_err(|e| format!("Failed to read design packs: {}", e))?;
+        serde_json::from_str(&content).unwrap_or_else(|_| Vec::new())
+    } else {
+        Vec::new()
+    };
+
+    // Find and update existing pack, or add new one
+    let mut found = false;
+    for pack in packs.iter_mut() {
+        if pack.get("packId").and_then(|v| v.as_str()) == Some(pack_id) {
+            *pack = new_pack.clone();
+            found = true;
+            break;
+        }
+    }
+    if !found {
+        packs.push(new_pack);
+    }
+
+    // Write packs back
+    let content = serde_json::to_string_pretty(&packs)
+        .map_err(|e| format!("Failed to serialize design packs: {}", e))?;
+    fs::write(&index_path, content)
+        .await
+        .map_err(|e| format!("Failed to write design packs: {}", e))?;
+
+    Ok(())
+}
+
+/// Delete a design pack
+#[tauri::command]
+pub async fn delete_design_pack(
+    app_handle: tauri::AppHandle,
+    pack_id: String,
+) -> Result<(), String> {
+    let index_path = get_index_path(&app_handle)?;
+
+    if !index_path.exists() {
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(&index_path)
+        .await
+        .map_err(|e| format!("Failed to read design packs: {}", e))?;
+
+    let mut packs: Vec<Value> = serde_json::from_str(&content).unwrap_or_else(|_| Vec::new());
+
+    // Remove the pack
+    packs.retain(|p| p.get("packId").and_then(|v| v.as_str()) != Some(&pack_id));
+
+    // Write packs back
+    let content = serde_json::to_string_pretty(&packs)
+        .map_err(|e| format!("Failed to serialize design packs: {}", e))?;
+    fs::write(&index_path, content)
+        .await
+        .map_err(|e| format!("Failed to write design packs: {}", e))?;
+
+    Ok(())
+}

--- a/src-tauri/src/commands/library_storage.rs
+++ b/src-tauri/src/commands/library_storage.rs
@@ -1,0 +1,347 @@
+use serde_json::Value;
+use std::path::PathBuf;
+use tokio::fs;
+
+const LIBRARY_DIR: &str = "library";
+const INDEX_FILE: &str = "index.json";
+const ARTIFACTS_DIR: &str = "artifacts";
+
+// Helper to get the library directory
+fn get_library_dir(app_handle: &tauri::AppHandle) -> Result<PathBuf, String> {
+    let app_data_dir = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data directory: {}", e))?;
+    Ok(app_data_dir.join(LIBRARY_DIR))
+}
+
+// Helper to get the index file path
+fn get_index_path(app_handle: &tauri::AppHandle) -> Result<PathBuf, String> {
+    Ok(get_library_dir(app_handle)?.join(INDEX_FILE))
+}
+
+// Helper to get the artifacts directory
+fn get_artifacts_dir(app_handle: &tauri::AppHandle) -> Result<PathBuf, String> {
+    Ok(get_library_dir(app_handle)?.join(ARTIFACTS_DIR))
+}
+
+// ============================================
+// Library Index Commands
+// ============================================
+
+/// Get the library index (list of all artifacts)
+#[tauri::command]
+pub async fn get_library_index(app_handle: tauri::AppHandle) -> Result<String, String> {
+    let index_path = get_index_path(&app_handle)?;
+
+    // If file doesn't exist, return default structure
+    if !index_path.exists() {
+        let default = serde_json::json!({
+            "version": 1,
+            "lastUpdated": chrono::Utc::now().to_rfc3339(),
+            "artifacts": []
+        });
+        return Ok(default.to_string());
+    }
+
+    fs::read_to_string(&index_path)
+        .await
+        .map_err(|e| format!("Failed to read library index: {}", e))
+}
+
+/// Save the library index
+#[tauri::command]
+pub async fn save_library_index(
+    app_handle: tauri::AppHandle,
+    index: String,
+) -> Result<(), String> {
+    let library_dir = get_library_dir(&app_handle)?;
+    let index_path = get_index_path(&app_handle)?;
+
+    // Create directory if it doesn't exist
+    fs::create_dir_all(&library_dir)
+        .await
+        .map_err(|e| format!("Failed to create library directory: {}", e))?;
+
+    // Validate JSON
+    let _: Value =
+        serde_json::from_str(&index).map_err(|e| format!("Invalid index JSON: {}", e))?;
+
+    // Write index
+    fs::write(&index_path, &index)
+        .await
+        .map_err(|e| format!("Failed to write library index: {}", e))?;
+
+    Ok(())
+}
+
+// ============================================
+// Artifact Commands
+// ============================================
+
+/// Get a specific artifact by ID
+#[tauri::command]
+pub async fn get_artifact(
+    app_handle: tauri::AppHandle,
+    artifact_id: String,
+) -> Result<String, String> {
+    let artifacts_dir = get_artifacts_dir(&app_handle)?;
+    let artifact_path = artifacts_dir.join(format!("{}.json", artifact_id));
+
+    if !artifact_path.exists() {
+        return Err(format!("Artifact not found: {}", artifact_id));
+    }
+
+    fs::read_to_string(&artifact_path)
+        .await
+        .map_err(|e| format!("Failed to read artifact: {}", e))
+}
+
+/// Save an artifact (create or update)
+#[tauri::command]
+pub async fn save_artifact(
+    app_handle: tauri::AppHandle,
+    artifact: String,
+) -> Result<(), String> {
+    let library_dir = get_library_dir(&app_handle)?;
+    let artifacts_dir = get_artifacts_dir(&app_handle)?;
+    let index_path = get_index_path(&app_handle)?;
+
+    // Create directories if they don't exist
+    fs::create_dir_all(&artifacts_dir)
+        .await
+        .map_err(|e| format!("Failed to create artifacts directory: {}", e))?;
+
+    // Parse the incoming artifact
+    let artifact_value: Value =
+        serde_json::from_str(&artifact).map_err(|e| format!("Invalid artifact JSON: {}", e))?;
+
+    let artifact_id = artifact_value
+        .get("artifactId")
+        .and_then(|v| v.as_str())
+        .ok_or("Artifact must have an artifactId")?;
+
+    // Save the full artifact to its own file
+    let artifact_path = artifacts_dir.join(format!("{}.json", artifact_id));
+    fs::write(&artifact_path, &artifact)
+        .await
+        .map_err(|e| format!("Failed to write artifact: {}", e))?;
+
+    // Update the index
+    let mut index: Value = if index_path.exists() {
+        let content = fs::read_to_string(&index_path)
+            .await
+            .map_err(|e| format!("Failed to read library index: {}", e))?;
+        serde_json::from_str(&content).unwrap_or_else(|_| {
+            serde_json::json!({
+                "version": 1,
+                "lastUpdated": chrono::Utc::now().to_rfc3339(),
+                "artifacts": []
+            })
+        })
+    } else {
+        serde_json::json!({
+            "version": 1,
+            "lastUpdated": chrono::Utc::now().to_rfc3339(),
+            "artifacts": []
+        })
+    };
+
+    // Create index entry (metadata only, no HTML content)
+    let index_entry = serde_json::json!({
+        "artifactId": artifact_value.get("artifactId"),
+        "projectId": artifact_value.get("projectId"),
+        "jobId": artifact_value.get("jobId"),
+        "type": artifact_value.get("type"),
+        "title": artifact_value.get("title"),
+        "grade": artifact_value.get("grade"),
+        "subject": artifact_value.get("subject"),
+        "objectiveTags": artifact_value.get("objectiveTags"),
+        "designPackId": artifact_value.get("designPackId"),
+        "createdAt": artifact_value.get("createdAt"),
+    });
+
+    // Update artifacts array in index
+    if let Some(artifacts) = index.get_mut("artifacts") {
+        if let Some(arr) = artifacts.as_array_mut() {
+            // Remove existing entry with same ID
+            arr.retain(|a| a.get("artifactId").and_then(|v| v.as_str()) != Some(artifact_id));
+            // Add new entry
+            arr.push(index_entry);
+        }
+    }
+
+    // Update lastUpdated
+    if let Some(obj) = index.as_object_mut() {
+        obj.insert(
+            "lastUpdated".to_string(),
+            Value::String(chrono::Utc::now().to_rfc3339()),
+        );
+    }
+
+    // Write index
+    let index_content = serde_json::to_string_pretty(&index)
+        .map_err(|e| format!("Failed to serialize index: {}", e))?;
+    fs::write(&index_path, index_content)
+        .await
+        .map_err(|e| format!("Failed to write library index: {}", e))?;
+
+    Ok(())
+}
+
+/// Delete an artifact
+#[tauri::command]
+pub async fn delete_artifact(
+    app_handle: tauri::AppHandle,
+    artifact_id: String,
+) -> Result<(), String> {
+    let artifacts_dir = get_artifacts_dir(&app_handle)?;
+    let index_path = get_index_path(&app_handle)?;
+    let artifact_path = artifacts_dir.join(format!("{}.json", artifact_id));
+
+    // Delete artifact file if it exists
+    if artifact_path.exists() {
+        fs::remove_file(&artifact_path)
+            .await
+            .map_err(|e| format!("Failed to delete artifact file: {}", e))?;
+    }
+
+    // Update index
+    if index_path.exists() {
+        let content = fs::read_to_string(&index_path)
+            .await
+            .map_err(|e| format!("Failed to read library index: {}", e))?;
+        let mut index: Value = serde_json::from_str(&content).unwrap_or_else(|_| {
+            serde_json::json!({
+                "version": 1,
+                "lastUpdated": chrono::Utc::now().to_rfc3339(),
+                "artifacts": []
+            })
+        });
+
+        if let Some(artifacts) = index.get_mut("artifacts") {
+            if let Some(arr) = artifacts.as_array_mut() {
+                arr.retain(|a| a.get("artifactId").and_then(|v| v.as_str()) != Some(&artifact_id));
+            }
+        }
+
+        if let Some(obj) = index.as_object_mut() {
+            obj.insert(
+                "lastUpdated".to_string(),
+                Value::String(chrono::Utc::now().to_rfc3339()),
+            );
+        }
+
+        let index_content = serde_json::to_string_pretty(&index)
+            .map_err(|e| format!("Failed to serialize index: {}", e))?;
+        fs::write(&index_path, index_content)
+            .await
+            .map_err(|e| format!("Failed to write library index: {}", e))?;
+    }
+
+    Ok(())
+}
+
+/// Search artifacts with filters
+#[tauri::command]
+pub async fn search_artifacts(
+    app_handle: tauri::AppHandle,
+    query: String,
+) -> Result<String, String> {
+    let index_path = get_index_path(&app_handle)?;
+
+    if !index_path.exists() {
+        return Ok("[]".to_string());
+    }
+
+    // Parse query
+    let query_value: Value =
+        serde_json::from_str(&query).map_err(|e| format!("Invalid query JSON: {}", e))?;
+
+    // Read index
+    let content = fs::read_to_string(&index_path)
+        .await
+        .map_err(|e| format!("Failed to read library index: {}", e))?;
+    let index: Value = serde_json::from_str(&content).unwrap_or_else(|_| {
+        serde_json::json!({
+            "version": 1,
+            "lastUpdated": chrono::Utc::now().to_rfc3339(),
+            "artifacts": []
+        })
+    });
+
+    let artifacts = index.get("artifacts").and_then(|v| v.as_array());
+    if artifacts.is_none() {
+        return Ok("[]".to_string());
+    }
+    let artifacts = artifacts.unwrap();
+
+    // Apply filters
+    let filtered: Vec<&Value> = artifacts
+        .iter()
+        .filter(|artifact| {
+            // Project ID filter
+            if let Some(project_id) = query_value.get("projectId").and_then(|v| v.as_str()) {
+                if artifact.get("projectId").and_then(|v| v.as_str()) != Some(project_id) {
+                    return false;
+                }
+            }
+
+            // Grade filter
+            if let Some(grade) = query_value.get("grade").and_then(|v| v.as_str()) {
+                if artifact.get("grade").and_then(|v| v.as_str()) != Some(grade) {
+                    return false;
+                }
+            }
+
+            // Subject filter
+            if let Some(subject) = query_value.get("subject").and_then(|v| v.as_str()) {
+                if artifact.get("subject").and_then(|v| v.as_str()) != Some(subject) {
+                    return false;
+                }
+            }
+
+            // Type filter
+            if let Some(artifact_type) = query_value.get("type").and_then(|v| v.as_str()) {
+                if artifact.get("type").and_then(|v| v.as_str()) != Some(artifact_type) {
+                    return false;
+                }
+            }
+
+            // Objective tag filter
+            if let Some(objective_tag) = query_value.get("objectiveTag").and_then(|v| v.as_str()) {
+                if let Some(tags) = artifact.get("objectiveTags").and_then(|v| v.as_array()) {
+                    let has_tag = tags.iter().any(|t| t.as_str() == Some(objective_tag));
+                    if !has_tag {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            }
+
+            // Design pack ID filter
+            if let Some(pack_id) = query_value.get("designPackId").and_then(|v| v.as_str()) {
+                if artifact.get("designPackId").and_then(|v| v.as_str()) != Some(pack_id) {
+                    return false;
+                }
+            }
+
+            // Search text filter (title)
+            if let Some(search_text) = query_value.get("searchText").and_then(|v| v.as_str()) {
+                let search_lower = search_text.to_lowercase();
+                if let Some(title) = artifact.get("title").and_then(|v| v.as_str()) {
+                    if !title.to_lowercase().contains(&search_lower) {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            }
+
+            true
+        })
+        .collect();
+
+    serde_json::to_string(&filtered).map_err(|e| format!("Failed to serialize results: {}", e))
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -2,3 +2,6 @@ pub mod file_system;
 pub mod dialog;
 pub mod ollama;
 pub mod learner_storage;
+pub mod library_storage;
+pub mod design_pack_storage;
+pub mod project_storage;

--- a/src-tauri/src/commands/project_storage.rs
+++ b/src-tauri/src/commands/project_storage.rs
@@ -1,0 +1,244 @@
+use serde_json::Value;
+use std::path::PathBuf;
+use tokio::fs;
+
+const PROJECTS_DIR: &str = "projects";
+const INDEX_FILE: &str = "projects.json";
+
+// Helper to get the projects directory
+fn get_projects_dir(app_handle: &tauri::AppHandle) -> Result<PathBuf, String> {
+    let app_data_dir = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data directory: {}", e))?;
+    Ok(app_data_dir.join(PROJECTS_DIR))
+}
+
+// Helper to get the index file path
+fn get_index_path(app_handle: &tauri::AppHandle) -> Result<PathBuf, String> {
+    Ok(get_projects_dir(app_handle)?.join(INDEX_FILE))
+}
+
+// ============================================
+// Local Project Commands
+// ============================================
+
+/// Get all local projects
+#[tauri::command]
+pub async fn get_local_projects(app_handle: tauri::AppHandle) -> Result<String, String> {
+    let index_path = get_index_path(&app_handle)?;
+
+    // If file doesn't exist, return empty array
+    if !index_path.exists() {
+        return Ok("[]".to_string());
+    }
+
+    fs::read_to_string(&index_path)
+        .await
+        .map_err(|e| format!("Failed to read projects: {}", e))
+}
+
+/// Get a specific project by ID
+#[tauri::command]
+pub async fn get_local_project(
+    app_handle: tauri::AppHandle,
+    project_id: String,
+) -> Result<String, String> {
+    let index_path = get_index_path(&app_handle)?;
+
+    if !index_path.exists() {
+        return Err(format!("Project not found: {}", project_id));
+    }
+
+    let content = fs::read_to_string(&index_path)
+        .await
+        .map_err(|e| format!("Failed to read projects: {}", e))?;
+
+    let projects: Vec<Value> = serde_json::from_str(&content).unwrap_or_else(|_| Vec::new());
+
+    for project in projects {
+        if project.get("projectId").and_then(|v| v.as_str()) == Some(&project_id) {
+            return serde_json::to_string(&project)
+                .map_err(|e| format!("Failed to serialize project: {}", e));
+        }
+    }
+
+    Err(format!("Project not found: {}", project_id))
+}
+
+/// Save a local project (create or update)
+#[tauri::command]
+pub async fn save_local_project(
+    app_handle: tauri::AppHandle,
+    project: String,
+) -> Result<(), String> {
+    let projects_dir = get_projects_dir(&app_handle)?;
+    let index_path = get_index_path(&app_handle)?;
+
+    // Create directory if it doesn't exist
+    fs::create_dir_all(&projects_dir)
+        .await
+        .map_err(|e| format!("Failed to create projects directory: {}", e))?;
+
+    // Parse the incoming project
+    let new_project: Value =
+        serde_json::from_str(&project).map_err(|e| format!("Invalid project JSON: {}", e))?;
+
+    let project_id = new_project
+        .get("projectId")
+        .and_then(|v| v.as_str())
+        .ok_or("Project must have a projectId")?;
+
+    // Read existing projects
+    let mut projects: Vec<Value> = if index_path.exists() {
+        let content = fs::read_to_string(&index_path)
+            .await
+            .map_err(|e| format!("Failed to read projects: {}", e))?;
+        serde_json::from_str(&content).unwrap_or_else(|_| Vec::new())
+    } else {
+        Vec::new()
+    };
+
+    // Find and update existing project, or add new one
+    let mut found = false;
+    for project in projects.iter_mut() {
+        if project.get("projectId").and_then(|v| v.as_str()) == Some(project_id) {
+            *project = new_project.clone();
+            found = true;
+            break;
+        }
+    }
+    if !found {
+        projects.push(new_project);
+    }
+
+    // Write projects back
+    let content = serde_json::to_string_pretty(&projects)
+        .map_err(|e| format!("Failed to serialize projects: {}", e))?;
+    fs::write(&index_path, content)
+        .await
+        .map_err(|e| format!("Failed to write projects: {}", e))?;
+
+    Ok(())
+}
+
+/// Delete a local project
+#[tauri::command]
+pub async fn delete_local_project(
+    app_handle: tauri::AppHandle,
+    project_id: String,
+) -> Result<(), String> {
+    let index_path = get_index_path(&app_handle)?;
+
+    if !index_path.exists() {
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(&index_path)
+        .await
+        .map_err(|e| format!("Failed to read projects: {}", e))?;
+
+    let mut projects: Vec<Value> = serde_json::from_str(&content).unwrap_or_else(|_| Vec::new());
+
+    // Remove the project
+    projects.retain(|p| p.get("projectId").and_then(|v| v.as_str()) != Some(&project_id));
+
+    // Write projects back
+    let content = serde_json::to_string_pretty(&projects)
+        .map_err(|e| format!("Failed to serialize projects: {}", e))?;
+    fs::write(&index_path, content)
+        .await
+        .map_err(|e| format!("Failed to write projects: {}", e))?;
+
+    Ok(())
+}
+
+/// Get projects by type (learning_path or quick_create)
+#[tauri::command]
+pub async fn get_projects_by_type(
+    app_handle: tauri::AppHandle,
+    project_type: String,
+) -> Result<String, String> {
+    let index_path = get_index_path(&app_handle)?;
+
+    if !index_path.exists() {
+        return Ok("[]".to_string());
+    }
+
+    let content = fs::read_to_string(&index_path)
+        .await
+        .map_err(|e| format!("Failed to read projects: {}", e))?;
+
+    let projects: Vec<Value> = serde_json::from_str(&content).unwrap_or_else(|_| Vec::new());
+
+    let filtered: Vec<&Value> = projects
+        .iter()
+        .filter(|p| p.get("type").and_then(|v| v.as_str()) == Some(&project_type))
+        .collect();
+
+    serde_json::to_string(&filtered).map_err(|e| format!("Failed to serialize projects: {}", e))
+}
+
+/// Add artifact ID to project's artifact list
+#[tauri::command]
+pub async fn add_artifact_to_project(
+    app_handle: tauri::AppHandle,
+    project_id: String,
+    artifact_id: String,
+) -> Result<(), String> {
+    let index_path = get_index_path(&app_handle)?;
+
+    if !index_path.exists() {
+        return Err(format!("Project not found: {}", project_id));
+    }
+
+    let content = fs::read_to_string(&index_path)
+        .await
+        .map_err(|e| format!("Failed to read projects: {}", e))?;
+
+    let mut projects: Vec<Value> = serde_json::from_str(&content).unwrap_or_else(|_| Vec::new());
+
+    let mut found = false;
+    for project in projects.iter_mut() {
+        if project.get("projectId").and_then(|v| v.as_str()) == Some(&project_id) {
+            // Get or create artifactIds array
+            if let Some(obj) = project.as_object_mut() {
+                let artifact_ids = obj
+                    .entry("artifactIds")
+                    .or_insert_with(|| Value::Array(Vec::new()));
+                if let Some(arr) = artifact_ids.as_array_mut() {
+                    // Only add if not already present
+                    let artifact_value = Value::String(artifact_id.clone());
+                    if !arr.contains(&artifact_value) {
+                        arr.push(artifact_value);
+                    }
+                }
+
+                // Update lastActivityDate
+                obj.insert(
+                    "lastActivityDate".to_string(),
+                    Value::String(chrono::Utc::now().to_rfc3339()),
+                );
+                obj.insert(
+                    "updatedAt".to_string(),
+                    Value::String(chrono::Utc::now().to_rfc3339()),
+                );
+            }
+            found = true;
+            break;
+        }
+    }
+
+    if !found {
+        return Err(format!("Project not found: {}", project_id));
+    }
+
+    // Write projects back
+    let content = serde_json::to_string_pretty(&projects)
+        .map_err(|e| format!("Failed to serialize projects: {}", e))?;
+    fs::write(&index_path, content)
+        .await
+        .map_err(|e| format!("Failed to write projects: {}", e))?;
+
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 mod commands;
 
-use commands::{file_system, dialog, ollama, learner_storage};
+use commands::{file_system, dialog, ollama, learner_storage, library_storage, design_pack_storage, project_storage};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -29,6 +29,25 @@ pub fn run() {
             learner_storage::save_learner_mastery,
             learner_storage::get_quick_check_history,
             learner_storage::save_quick_check_result,
+            // Library storage commands (Issue #20)
+            library_storage::get_library_index,
+            library_storage::save_library_index,
+            library_storage::get_artifact,
+            library_storage::save_artifact,
+            library_storage::delete_artifact,
+            library_storage::search_artifacts,
+            // Design pack storage commands (Issue #20)
+            design_pack_storage::get_design_packs,
+            design_pack_storage::get_design_pack,
+            design_pack_storage::save_design_pack,
+            design_pack_storage::delete_design_pack,
+            // Local project storage commands (Issue #20)
+            project_storage::get_local_projects,
+            project_storage::get_local_project,
+            project_storage::save_local_project,
+            project_storage::delete_local_project,
+            project_storage::get_projects_by_type,
+            project_storage::add_artifact_to_project,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/__tests__/stores/artifactStore.test.ts
+++ b/src/__tests__/stores/artifactStore.test.ts
@@ -1,0 +1,388 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useArtifactStore } from "@/stores/artifactStore";
+import type { LocalArtifact } from "@/types";
+
+// Mock the library-storage service
+vi.mock("@/services/library-storage", () => ({
+  getArtifacts: vi.fn().mockResolvedValue([]),
+  getArtifact: vi.fn().mockResolvedValue(null),
+  saveArtifact: vi.fn().mockResolvedValue(undefined),
+  deleteArtifact: vi.fn().mockResolvedValue(undefined),
+  searchArtifacts: vi.fn().mockResolvedValue([]),
+  saveArtifactsFromGeneration: vi.fn().mockResolvedValue([]),
+}));
+
+const mockArtifact: Omit<LocalArtifact, "htmlContent"> = {
+  artifactId: "artifact-1",
+  projectId: "project-1",
+  jobId: "job-1",
+  type: "student_page",
+  title: "Math Worksheet - Addition",
+  grade: "2",
+  subject: "Math",
+  objectiveTags: ["2.MATH.ADD.BASIC"],
+  createdAt: new Date().toISOString(),
+};
+
+const mockArtifact2: Omit<LocalArtifact, "htmlContent"> = {
+  artifactId: "artifact-2",
+  projectId: "project-1",
+  jobId: "job-1",
+  type: "answer_key",
+  title: "Math Worksheet - Answer Key",
+  grade: "2",
+  subject: "Math",
+  objectiveTags: ["2.MATH.ADD.BASIC"],
+  createdAt: new Date().toISOString(),
+};
+
+const mockArtifact3: Omit<LocalArtifact, "htmlContent"> = {
+  artifactId: "artifact-3",
+  projectId: "project-2",
+  jobId: "job-2",
+  type: "lesson_plan",
+  title: "Reading Lesson Plan",
+  grade: "K",
+  subject: "Reading",
+  objectiveTags: ["K.READING.PHONICS"],
+  createdAt: new Date().toISOString(),
+};
+
+describe("artifactStore", () => {
+  beforeEach(() => {
+    // Reset store state
+    useArtifactStore.setState({
+      artifacts: [],
+      isLoading: false,
+      error: null,
+      currentArtifact: null,
+      isLoadingCurrent: false,
+      viewMode: "grid",
+      sortBy: "date_desc",
+      filters: {
+        projects: [],
+        grades: [],
+        subjects: [],
+        types: [],
+        objectiveTags: [],
+      },
+      searchQuery: "",
+    });
+    vi.clearAllMocks();
+  });
+
+  describe("initial state", () => {
+    it("starts with empty artifacts", () => {
+      const { artifacts } = useArtifactStore.getState();
+      expect(artifacts).toEqual([]);
+    });
+
+    it("starts with grid view mode", () => {
+      const { viewMode } = useArtifactStore.getState();
+      expect(viewMode).toBe("grid");
+    });
+
+    it("starts with date_desc sort", () => {
+      const { sortBy } = useArtifactStore.getState();
+      expect(sortBy).toBe("date_desc");
+    });
+
+    it("starts with empty filters", () => {
+      const { filters } = useArtifactStore.getState();
+      expect(filters.projects).toEqual([]);
+      expect(filters.grades).toEqual([]);
+      expect(filters.subjects).toEqual([]);
+      expect(filters.types).toEqual([]);
+    });
+  });
+
+  describe("computed helpers", () => {
+    it("getArtifactsByProject returns artifacts for specific project", () => {
+      useArtifactStore.setState({
+        artifacts: [mockArtifact, mockArtifact2, mockArtifact3],
+      });
+
+      const projectArtifacts = useArtifactStore.getState().getArtifactsByProject("project-1");
+      expect(projectArtifacts).toHaveLength(2);
+      expect(projectArtifacts.every((a) => a.projectId === "project-1")).toBe(true);
+    });
+
+    it("getArtifactsByType returns artifacts of specific type", () => {
+      useArtifactStore.setState({
+        artifacts: [mockArtifact, mockArtifact2, mockArtifact3],
+      });
+
+      const studentPages = useArtifactStore.getState().getArtifactsByType("student_page");
+      expect(studentPages).toHaveLength(1);
+      expect(studentPages[0].type).toBe("student_page");
+    });
+
+    it("getFilteredArtifacts respects grade filter", () => {
+      useArtifactStore.setState({
+        artifacts: [mockArtifact, mockArtifact2, mockArtifact3],
+        filters: {
+          projects: [],
+          grades: ["K"],
+          subjects: [],
+          types: [],
+          objectiveTags: [],
+        },
+      });
+
+      const filtered = useArtifactStore.getState().getFilteredArtifacts();
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].grade).toBe("K");
+    });
+
+    it("getFilteredArtifacts respects subject filter", () => {
+      useArtifactStore.setState({
+        artifacts: [mockArtifact, mockArtifact2, mockArtifact3],
+        filters: {
+          projects: [],
+          grades: [],
+          subjects: ["Math"],
+          types: [],
+          objectiveTags: [],
+        },
+      });
+
+      const filtered = useArtifactStore.getState().getFilteredArtifacts();
+      expect(filtered).toHaveLength(2);
+      expect(filtered.every((a) => a.subject === "Math")).toBe(true);
+    });
+
+    it("getFilteredArtifacts respects type filter", () => {
+      useArtifactStore.setState({
+        artifacts: [mockArtifact, mockArtifact2, mockArtifact3],
+        filters: {
+          projects: [],
+          grades: [],
+          subjects: [],
+          types: ["answer_key"],
+          objectiveTags: [],
+        },
+      });
+
+      const filtered = useArtifactStore.getState().getFilteredArtifacts();
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].type).toBe("answer_key");
+    });
+
+    it("getFilteredArtifacts respects project filter", () => {
+      useArtifactStore.setState({
+        artifacts: [mockArtifact, mockArtifact2, mockArtifact3],
+        filters: {
+          projects: ["project-2"],
+          grades: [],
+          subjects: [],
+          types: [],
+          objectiveTags: [],
+        },
+      });
+
+      const filtered = useArtifactStore.getState().getFilteredArtifacts();
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].projectId).toBe("project-2");
+    });
+
+    it("getFilteredArtifacts respects objective tag filter", () => {
+      useArtifactStore.setState({
+        artifacts: [mockArtifact, mockArtifact2, mockArtifact3],
+        filters: {
+          projects: [],
+          grades: [],
+          subjects: [],
+          types: [],
+          objectiveTags: ["K.READING.PHONICS"],
+        },
+      });
+
+      const filtered = useArtifactStore.getState().getFilteredArtifacts();
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].objectiveTags).toContain("K.READING.PHONICS");
+    });
+
+    it("getFilteredArtifacts respects search query", () => {
+      useArtifactStore.setState({
+        artifacts: [mockArtifact, mockArtifact2, mockArtifact3],
+        searchQuery: "reading",
+      });
+
+      const filtered = useArtifactStore.getState().getFilteredArtifacts();
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].title.toLowerCase()).toContain("reading");
+    });
+
+    it("getFilteredArtifacts sorts by date descending", () => {
+      const older = { ...mockArtifact, artifactId: "old", createdAt: "2024-01-01T00:00:00Z" };
+      const newer = { ...mockArtifact2, artifactId: "new", createdAt: "2024-12-01T00:00:00Z" };
+
+      useArtifactStore.setState({
+        artifacts: [older, newer],
+        sortBy: "date_desc",
+      });
+
+      const filtered = useArtifactStore.getState().getFilteredArtifacts();
+      expect(filtered[0].artifactId).toBe("new");
+      expect(filtered[1].artifactId).toBe("old");
+    });
+
+    it("getFilteredArtifacts sorts by date ascending", () => {
+      const older = { ...mockArtifact, artifactId: "old", createdAt: "2024-01-01T00:00:00Z" };
+      const newer = { ...mockArtifact2, artifactId: "new", createdAt: "2024-12-01T00:00:00Z" };
+
+      useArtifactStore.setState({
+        artifacts: [newer, older],
+        sortBy: "date_asc",
+      });
+
+      const filtered = useArtifactStore.getState().getFilteredArtifacts();
+      expect(filtered[0].artifactId).toBe("old");
+      expect(filtered[1].artifactId).toBe("new");
+    });
+
+    it("getFilteredArtifacts sorts by title ascending", () => {
+      const a = { ...mockArtifact, artifactId: "a", title: "Alpha" };
+      const b = { ...mockArtifact2, artifactId: "b", title: "Beta" };
+
+      useArtifactStore.setState({
+        artifacts: [b, a],
+        sortBy: "title_asc",
+      });
+
+      const filtered = useArtifactStore.getState().getFilteredArtifacts();
+      expect(filtered[0].artifactId).toBe("a");
+      expect(filtered[1].artifactId).toBe("b");
+    });
+
+    it("getFilteredArtifacts sorts by grade", () => {
+      const k = { ...mockArtifact, artifactId: "k", grade: "K" as const };
+      const g2 = { ...mockArtifact2, artifactId: "g2", grade: "2" as const };
+
+      useArtifactStore.setState({
+        artifacts: [g2, k],
+        sortBy: "grade",
+      });
+
+      const filtered = useArtifactStore.getState().getFilteredArtifacts();
+      expect(filtered[0].artifactId).toBe("k");
+      expect(filtered[1].artifactId).toBe("g2");
+    });
+  });
+
+  describe("UI state actions", () => {
+    it("setViewMode changes view mode", () => {
+      useArtifactStore.getState().setViewMode("list");
+      expect(useArtifactStore.getState().viewMode).toBe("list");
+
+      useArtifactStore.getState().setViewMode("grid");
+      expect(useArtifactStore.getState().viewMode).toBe("grid");
+    });
+
+    it("setSortBy changes sort option", () => {
+      useArtifactStore.getState().setSortBy("title_asc");
+      expect(useArtifactStore.getState().sortBy).toBe("title_asc");
+    });
+
+    it("setFilters updates filters", () => {
+      useArtifactStore.getState().setFilters({ grades: ["K", "1"] });
+      expect(useArtifactStore.getState().filters.grades).toEqual(["K", "1"]);
+    });
+
+    it("setFilters merges with existing filters", () => {
+      useArtifactStore.getState().setFilters({ grades: ["K"] });
+      useArtifactStore.getState().setFilters({ subjects: ["Math"] });
+
+      const { filters } = useArtifactStore.getState();
+      expect(filters.grades).toEqual(["K"]);
+      expect(filters.subjects).toEqual(["Math"]);
+    });
+
+    it("clearFilters resets all filters", () => {
+      useArtifactStore.setState({
+        filters: {
+          projects: ["p1"],
+          grades: ["K", "1"],
+          subjects: ["Math"],
+          types: ["student_page"],
+          objectiveTags: ["tag1"],
+        },
+        searchQuery: "test",
+      });
+
+      useArtifactStore.getState().clearFilters();
+
+      const { filters, searchQuery } = useArtifactStore.getState();
+      expect(filters.projects).toEqual([]);
+      expect(filters.grades).toEqual([]);
+      expect(filters.subjects).toEqual([]);
+      expect(filters.types).toEqual([]);
+      expect(filters.objectiveTags).toEqual([]);
+      expect(searchQuery).toBe("");
+    });
+
+    it("setSearchQuery updates search query", () => {
+      useArtifactStore.getState().setSearchQuery("worksheet");
+      expect(useArtifactStore.getState().searchQuery).toBe("worksheet");
+    });
+
+    it("setCurrentArtifact updates current artifact", () => {
+      const fullArtifact: LocalArtifact = {
+        ...mockArtifact,
+        htmlContent: "<h1>Test</h1>",
+      };
+
+      useArtifactStore.getState().setCurrentArtifact(fullArtifact);
+      expect(useArtifactStore.getState().currentArtifact).toEqual(fullArtifact);
+    });
+  });
+
+  describe("error handling", () => {
+    it("can set and clear errors", () => {
+      useArtifactStore.setState({
+        error: "Test error",
+      });
+
+      expect(useArtifactStore.getState().error).toBe("Test error");
+
+      useArtifactStore.getState().clearError();
+
+      expect(useArtifactStore.getState().error).toBeNull();
+    });
+  });
+
+  describe("reset", () => {
+    it("resets all state to defaults", () => {
+      useArtifactStore.setState({
+        artifacts: [mockArtifact],
+        isLoading: true,
+        error: "some error",
+        currentArtifact: { ...mockArtifact, htmlContent: "<h1>Test</h1>" },
+        isLoadingCurrent: true,
+        viewMode: "list",
+        sortBy: "title_asc",
+        filters: {
+          projects: ["p1"],
+          grades: ["K"],
+          subjects: ["Math"],
+          types: ["student_page"],
+          objectiveTags: ["tag1"],
+        },
+        searchQuery: "test",
+      });
+
+      useArtifactStore.getState().reset();
+
+      const state = useArtifactStore.getState();
+      expect(state.artifacts).toEqual([]);
+      expect(state.isLoading).toBe(false);
+      expect(state.error).toBeNull();
+      expect(state.currentArtifact).toBeNull();
+      expect(state.isLoadingCurrent).toBe(false);
+      expect(state.viewMode).toBe("grid");
+      expect(state.sortBy).toBe("date_desc");
+      expect(state.filters.projects).toEqual([]);
+      expect(state.searchQuery).toBe("");
+    });
+  });
+});

--- a/src/__tests__/stores/unifiedProjectStore.test.ts
+++ b/src/__tests__/stores/unifiedProjectStore.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useUnifiedProjectStore } from "@/stores/unifiedProjectStore";
+import type { UnifiedProject } from "@/types";
+
+// Mock the local-project-storage service
+vi.mock("@/services/local-project-storage", () => ({
+  getLocalProjects: vi.fn().mockResolvedValue([]),
+  getLocalProject: vi.fn().mockResolvedValue(null),
+  createLocalProject: vi.fn().mockImplementation((data) =>
+    Promise.resolve({
+      projectId: "test-project-id",
+      type: data.type,
+      name: data.name,
+      grade: data.grade,
+      gradeBand: data.grade === "K" ? "K" : data.grade <= "3" ? data.grade : "4-6",
+      subjectFocus: data.subjectFocus || [],
+      artifactIds: [],
+      status: "pending",
+      lastActivityDate: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    })
+  ),
+  updateLocalProject: vi.fn().mockImplementation((projectId, updates) =>
+    Promise.resolve({ projectId, ...updates })
+  ),
+  deleteLocalProject: vi.fn().mockResolvedValue(undefined),
+  getProjectsByType: vi.fn().mockResolvedValue([]),
+  addArtifactToProject: vi.fn().mockResolvedValue(undefined),
+  linkObjectiveToProject: vi.fn().mockResolvedValue(undefined),
+  unlinkObjectiveFromProject: vi.fn().mockResolvedValue(undefined),
+  getProjectSummaries: vi.fn().mockResolvedValue([]),
+  getMostRecentProject: vi.fn().mockResolvedValue(null),
+  setProjectDesignPack: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockProject: UnifiedProject = {
+  projectId: "test-project-1",
+  type: "quick_create",
+  name: "Test Math Worksheets",
+  grade: "2",
+  gradeBand: "2",
+  subjectFocus: ["Math"],
+  artifactIds: [],
+  status: "pending",
+  lastActivityDate: new Date().toISOString(),
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const mockLearningPathProject: UnifiedProject = {
+  projectId: "test-lp-1",
+  type: "learning_path",
+  name: "Math Learning Path",
+  grade: "K",
+  gradeBand: "K",
+  subjectFocus: ["Math"],
+  learnerId: "learner-1",
+  linkedObjectiveIds: ["K.MATH.COUNT.1_20"],
+  artifactIds: [],
+  status: "pending",
+  lastActivityDate: new Date().toISOString(),
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+describe("unifiedProjectStore", () => {
+  beforeEach(() => {
+    // Reset store state
+    useUnifiedProjectStore.setState({
+      projects: [],
+      isLoading: false,
+      error: null,
+      currentProjectId: null,
+      currentProject: null,
+      summaries: [],
+    });
+    vi.clearAllMocks();
+    // Clear localStorage mock
+    localStorage.clear();
+  });
+
+  describe("initial state", () => {
+    it("starts with empty projects", () => {
+      const { projects } = useUnifiedProjectStore.getState();
+      expect(projects).toEqual([]);
+    });
+
+    it("starts with no current project", () => {
+      const { currentProjectId, currentProject } = useUnifiedProjectStore.getState();
+      expect(currentProjectId).toBeNull();
+      expect(currentProject).toBeNull();
+    });
+
+    it("starts with empty summaries", () => {
+      const { summaries } = useUnifiedProjectStore.getState();
+      expect(summaries).toEqual([]);
+    });
+  });
+
+  describe("computed helpers", () => {
+    it("getProjectById returns correct project", () => {
+      useUnifiedProjectStore.setState({
+        projects: [mockProject, mockLearningPathProject],
+      });
+
+      const project = useUnifiedProjectStore.getState().getProjectById("test-project-1");
+      expect(project).toEqual(mockProject);
+    });
+
+    it("getProjectById returns null for non-existent project", () => {
+      useUnifiedProjectStore.setState({
+        projects: [mockProject],
+      });
+
+      const project = useUnifiedProjectStore.getState().getProjectById("non-existent");
+      expect(project).toBeNull();
+    });
+
+    it("getLearningPathProjects returns only learning path projects", () => {
+      useUnifiedProjectStore.setState({
+        projects: [mockProject, mockLearningPathProject],
+      });
+
+      const lpProjects = useUnifiedProjectStore.getState().getLearningPathProjects();
+      expect(lpProjects).toHaveLength(1);
+      expect(lpProjects[0].type).toBe("learning_path");
+    });
+
+    it("getQuickCreateProjects returns only quick create projects", () => {
+      useUnifiedProjectStore.setState({
+        projects: [mockProject, mockLearningPathProject],
+      });
+
+      const qcProjects = useUnifiedProjectStore.getState().getQuickCreateProjects();
+      expect(qcProjects).toHaveLength(1);
+      expect(qcProjects[0].type).toBe("quick_create");
+    });
+
+    it("getProjectsByLearner returns projects for specific learner", () => {
+      useUnifiedProjectStore.setState({
+        projects: [mockProject, mockLearningPathProject],
+      });
+
+      const learnerProjects = useUnifiedProjectStore.getState().getProjectsByLearner("learner-1");
+      expect(learnerProjects).toHaveLength(1);
+      expect(learnerProjects[0].learnerId).toBe("learner-1");
+    });
+
+    it("getCurrentProject returns current project when set", () => {
+      useUnifiedProjectStore.setState({
+        projects: [mockProject],
+        currentProjectId: "test-project-1",
+      });
+
+      const currentProject = useUnifiedProjectStore.getState().getCurrentProject();
+      expect(currentProject).toEqual(mockProject);
+    });
+
+    it("getCurrentProject returns null when no current project", () => {
+      useUnifiedProjectStore.setState({
+        projects: [mockProject],
+        currentProjectId: null,
+      });
+
+      const currentProject = useUnifiedProjectStore.getState().getCurrentProject();
+      expect(currentProject).toBeNull();
+    });
+  });
+
+  describe("project management", () => {
+    it("can add a project", () => {
+      useUnifiedProjectStore.setState({
+        projects: [mockProject],
+      });
+
+      const { projects } = useUnifiedProjectStore.getState();
+      expect(projects).toHaveLength(1);
+      expect(projects[0].name).toBe("Test Math Worksheets");
+    });
+
+    it("can set current project", () => {
+      useUnifiedProjectStore.setState({
+        projects: [mockProject],
+      });
+
+      useUnifiedProjectStore.getState().setCurrentProject("test-project-1");
+
+      const { currentProjectId, currentProject } = useUnifiedProjectStore.getState();
+      expect(currentProjectId).toBe("test-project-1");
+      expect(currentProject).toEqual(mockProject);
+    });
+
+    it("can clear current project", () => {
+      useUnifiedProjectStore.setState({
+        projects: [mockProject],
+        currentProjectId: "test-project-1",
+        currentProject: mockProject,
+      });
+
+      useUnifiedProjectStore.getState().setCurrentProject(null);
+
+      const { currentProjectId, currentProject } = useUnifiedProjectStore.getState();
+      expect(currentProjectId).toBeNull();
+      expect(currentProject).toBeNull();
+    });
+  });
+
+  describe("artifact management", () => {
+    it("addArtifact updates project artifact list", async () => {
+      useUnifiedProjectStore.setState({
+        projects: [{ ...mockProject, artifactIds: [] }],
+        currentProjectId: "test-project-1",
+        currentProject: { ...mockProject, artifactIds: [] },
+      });
+
+      await useUnifiedProjectStore.getState().addArtifact("test-project-1", "artifact-1");
+
+      const { projects, currentProject } = useUnifiedProjectStore.getState();
+      expect(projects[0].artifactIds).toContain("artifact-1");
+      expect(currentProject?.artifactIds).toContain("artifact-1");
+    });
+
+    it("addArtifact does not duplicate artifact IDs", async () => {
+      useUnifiedProjectStore.setState({
+        projects: [{ ...mockProject, artifactIds: ["artifact-1"] }],
+        currentProjectId: "test-project-1",
+        currentProject: { ...mockProject, artifactIds: ["artifact-1"] },
+      });
+
+      await useUnifiedProjectStore.getState().addArtifact("test-project-1", "artifact-1");
+
+      const { projects } = useUnifiedProjectStore.getState();
+      expect(projects[0].artifactIds).toEqual(["artifact-1"]);
+    });
+  });
+
+  describe("objective management", () => {
+    it("linkObjective adds objective to project", async () => {
+      useUnifiedProjectStore.setState({
+        projects: [{ ...mockLearningPathProject, linkedObjectiveIds: [] }],
+      });
+
+      await useUnifiedProjectStore.getState().linkObjective("test-lp-1", "K.MATH.ADD.BASIC");
+
+      const { projects } = useUnifiedProjectStore.getState();
+      expect(projects[0].linkedObjectiveIds).toContain("K.MATH.ADD.BASIC");
+    });
+
+    it("unlinkObjective removes objective from project", async () => {
+      useUnifiedProjectStore.setState({
+        projects: [mockLearningPathProject],
+      });
+
+      await useUnifiedProjectStore.getState().unlinkObjective("test-lp-1", "K.MATH.COUNT.1_20");
+
+      const { projects } = useUnifiedProjectStore.getState();
+      expect(projects[0].linkedObjectiveIds).not.toContain("K.MATH.COUNT.1_20");
+    });
+  });
+
+  describe("design pack management", () => {
+    it("setDesignPack updates project design pack", async () => {
+      useUnifiedProjectStore.setState({
+        projects: [mockProject],
+        currentProjectId: "test-project-1",
+        currentProject: mockProject,
+      });
+
+      await useUnifiedProjectStore.getState().setDesignPack("test-project-1", "pack-1");
+
+      const { projects, currentProject } = useUnifiedProjectStore.getState();
+      expect(projects[0].defaultDesignPackId).toBe("pack-1");
+      expect(currentProject?.defaultDesignPackId).toBe("pack-1");
+    });
+  });
+
+  describe("error handling", () => {
+    it("can set and clear errors", () => {
+      useUnifiedProjectStore.setState({
+        error: "Test error",
+      });
+
+      expect(useUnifiedProjectStore.getState().error).toBe("Test error");
+
+      useUnifiedProjectStore.getState().clearError();
+
+      expect(useUnifiedProjectStore.getState().error).toBeNull();
+    });
+  });
+
+  describe("reset", () => {
+    it("resets all state to defaults", () => {
+      useUnifiedProjectStore.setState({
+        projects: [mockProject],
+        isLoading: true,
+        error: "some error",
+        currentProjectId: "test-project-1",
+        currentProject: mockProject,
+        summaries: [{ projectId: "test-project-1", type: "quick_create", name: "Test", grade: "2", subjectFocus: [], lastActivityDate: "", artifactCount: 0 }],
+      });
+
+      useUnifiedProjectStore.getState().reset();
+
+      const state = useUnifiedProjectStore.getState();
+      expect(state.projects).toEqual([]);
+      expect(state.isLoading).toBe(false);
+      expect(state.error).toBeNull();
+      expect(state.currentProjectId).toBeNull();
+      expect(state.currentProject).toBeNull();
+      expect(state.summaries).toEqual([]);
+    });
+  });
+});

--- a/src/__tests__/types/artifacts.test.ts
+++ b/src/__tests__/types/artifacts.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import {
+  gradeToGradeBand,
+  mapLegacyArtifactType,
+  getArtifactTypeLabel,
+  getProjectTypeLabel,
+  parseObjectiveId,
+} from "@/types/artifacts";
+
+describe("artifacts types", () => {
+  describe("gradeToGradeBand", () => {
+    it("returns K for kindergarten", () => {
+      expect(gradeToGradeBand("K")).toBe("K");
+    });
+
+    it("returns grade as-is for grades 1-3", () => {
+      expect(gradeToGradeBand("1")).toBe("1");
+      expect(gradeToGradeBand("2")).toBe("2");
+      expect(gradeToGradeBand("3")).toBe("3");
+    });
+
+    it("returns 4-6 for grades 4-6", () => {
+      expect(gradeToGradeBand("4")).toBe("4-6");
+      expect(gradeToGradeBand("5")).toBe("4-6");
+      expect(gradeToGradeBand("6")).toBe("4-6");
+    });
+  });
+
+  describe("mapLegacyArtifactType", () => {
+    it("maps worksheet to student_page", () => {
+      expect(mapLegacyArtifactType("worksheet")).toBe("student_page");
+    });
+
+    it("maps student_activity to student_page", () => {
+      expect(mapLegacyArtifactType("student_activity")).toBe("student_page");
+    });
+
+    it("maps lesson_plan to lesson_plan", () => {
+      expect(mapLegacyArtifactType("lesson_plan")).toBe("lesson_plan");
+    });
+
+    it("maps answer_key to answer_key", () => {
+      expect(mapLegacyArtifactType("answer_key")).toBe("answer_key");
+    });
+
+    it("maps teacher_script to teacher_script", () => {
+      expect(mapLegacyArtifactType("teacher_script")).toBe("teacher_script");
+    });
+
+    it("defaults to student_page for unknown types", () => {
+      expect(mapLegacyArtifactType("unknown")).toBe("student_page");
+    });
+  });
+
+  describe("getArtifactTypeLabel", () => {
+    it("returns correct labels", () => {
+      expect(getArtifactTypeLabel("student_page")).toBe("Student Page");
+      expect(getArtifactTypeLabel("teacher_script")).toBe("Teacher Script");
+      expect(getArtifactTypeLabel("answer_key")).toBe("Answer Key");
+      expect(getArtifactTypeLabel("lesson_plan")).toBe("Lesson Plan");
+      expect(getArtifactTypeLabel("print_pack")).toBe("Print Pack");
+    });
+  });
+
+  describe("getProjectTypeLabel", () => {
+    it("returns correct labels", () => {
+      expect(getProjectTypeLabel("learning_path")).toBe("Learning Path");
+      expect(getProjectTypeLabel("quick_create")).toBe("Quick Create");
+    });
+  });
+
+  describe("parseObjectiveId", () => {
+    it("parses valid objective IDs", () => {
+      const result = parseObjectiveId("K.MATH.COUNT.1_20");
+      expect(result).toEqual({
+        grade: "K",
+        subject: "MATH",
+        domain: "COUNT",
+        specific: "1_20",
+      });
+    });
+
+    it("handles complex objective IDs", () => {
+      const result = parseObjectiveId("2.READING.COMPREH.MAIN_IDEA");
+      expect(result).toEqual({
+        grade: "2",
+        subject: "READING",
+        domain: "COMPREH",
+        specific: "MAIN_IDEA",
+      });
+    });
+
+    it("returns null for invalid objective IDs", () => {
+      expect(parseObjectiveId("invalid")).toBeNull();
+      expect(parseObjectiveId("K.MATH")).toBeNull();
+    });
+
+    it("handles objective IDs without specific part", () => {
+      const result = parseObjectiveId("K.MATH.COUNT");
+      expect(result).toEqual({
+        grade: "K",
+        subject: "MATH",
+        domain: "COUNT",
+        specific: "",
+      });
+    });
+  });
+});

--- a/src/components/design-packs/DesignPacksPanel.tsx
+++ b/src/components/design-packs/DesignPacksPanel.tsx
@@ -1,0 +1,411 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  Link,
+  FileText,
+  Image,
+  X,
+  Plus,
+  Upload,
+  Loader2,
+  Package,
+  Pencil,
+  Trash2,
+  Check,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { useDesignPackStore } from "@/stores/designPackStore";
+import { cn } from "@/lib/utils";
+import type { DesignPack, DesignPackItem } from "@/types";
+
+// Helper to read file as base64
+async function readFileAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      const base64 = result.split(",")[1];
+      resolve(base64);
+    };
+    reader.onerror = () => reject(new Error("Failed to read file"));
+    reader.readAsDataURL(file);
+  });
+}
+
+const getIcon = (type: string) => {
+  switch (type) {
+    case "url":
+      return Link;
+    case "pdf":
+      return FileText;
+    case "image":
+      return Image;
+    default:
+      return FileText;
+  }
+};
+
+export function DesignPacksPanel() {
+  const {
+    packs,
+    isLoading,
+    selectedPackId,
+    loadPacks,
+    createPack,
+    deletePack,
+    addItem,
+    removeItem,
+    selectPack,
+  } = useDesignPackStore();
+
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const [newPackName, setNewPackName] = useState("");
+  const [expandedPackId, setExpandedPackId] = useState<string | null>(null);
+
+  // Load packs on mount
+  useEffect(() => {
+    loadPacks();
+  }, [loadPacks]);
+
+  // Auto-expand selected pack
+  useEffect(() => {
+    if (selectedPackId) {
+      setExpandedPackId(selectedPackId);
+    }
+  }, [selectedPackId]);
+
+  const handleCreatePack = async () => {
+    if (!newPackName.trim()) return;
+
+    try {
+      const pack = await createPack({ name: newPackName.trim() });
+      setNewPackName("");
+      setIsCreateDialogOpen(false);
+      setExpandedPackId(pack.packId);
+      selectPack(pack.packId);
+    } catch {
+      // Error handled by store
+    }
+  };
+
+  const handleDeletePack = async (packId: string) => {
+    if (confirm("Are you sure you want to delete this design pack?")) {
+      await deletePack(packId);
+    }
+  };
+
+  const handleDrop = useCallback(
+    async (e: React.DragEvent, packId: string) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const files = Array.from(e.dataTransfer.files);
+      const text = e.dataTransfer.getData("text/plain");
+      const url = e.dataTransfer.getData("text/uri-list");
+
+      // Handle URL drop
+      if (url || (text && text.startsWith("http"))) {
+        const droppedUrl = url || text;
+        try {
+          await addItem(packId, {
+            type: "url",
+            title: new URL(droppedUrl).hostname,
+            sourceUrl: droppedUrl,
+          });
+        } catch {
+          // Error handled by store
+        }
+        return;
+      }
+
+      // Handle file drops
+      for (const file of files) {
+        try {
+          if (file.type === "application/pdf") {
+            const base64Content = await readFileAsBase64(file);
+            await addItem(packId, {
+              type: "pdf",
+              title: file.name,
+              content: base64Content,
+            });
+          } else if (file.type.startsWith("image/")) {
+            const base64Content = await readFileAsBase64(file);
+            await addItem(packId, {
+              type: "image",
+              title: file.name,
+              content: base64Content,
+              storagePath: file.type,
+            });
+          }
+        } catch {
+          // Error handled by store
+        }
+      }
+    },
+    [addItem]
+  );
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  const handleAddUrl = async (packId: string) => {
+    const url = prompt("Enter a URL for design inspiration:");
+    if (url && url.startsWith("http")) {
+      try {
+        await addItem(packId, {
+          type: "url",
+          title: new URL(url).hostname,
+          sourceUrl: url,
+        });
+      } catch {
+        // Error handled by store
+      }
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-medium text-muted-foreground">Design Packs</h2>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          onClick={() => setIsCreateDialogOpen(true)}
+          title="Create Design Pack"
+        >
+          <Plus className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* Empty state */}
+      {packs.length === 0 && (
+        <div className="border-2 border-dashed rounded-lg p-4 text-center">
+          <Package className="h-6 w-6 mx-auto text-muted-foreground/50 mb-2" />
+          <p className="text-xs text-muted-foreground mb-2">
+            Create a Design Pack to save your inspiration items
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setIsCreateDialogOpen(true)}
+          >
+            <Plus className="h-3 w-3 mr-1" />
+            New Pack
+          </Button>
+        </div>
+      )}
+
+      {/* Design packs list */}
+      {packs.length > 0 && (
+        <div className="space-y-2">
+          {packs.map((pack) => (
+            <DesignPackCard
+              key={pack.packId}
+              pack={pack}
+              isExpanded={expandedPackId === pack.packId}
+              isSelected={selectedPackId === pack.packId}
+              onToggleExpand={() =>
+                setExpandedPackId(expandedPackId === pack.packId ? null : pack.packId)
+              }
+              onSelect={() => selectPack(selectedPackId === pack.packId ? null : pack.packId)}
+              onDelete={() => handleDeletePack(pack.packId)}
+              onAddUrl={() => handleAddUrl(pack.packId)}
+              onRemoveItem={(itemId) => removeItem(pack.packId, itemId)}
+              onDrop={(e) => handleDrop(e, pack.packId)}
+              onDragOver={handleDragOver}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Create Dialog */}
+      <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Design Pack</DialogTitle>
+            <DialogDescription>
+              Create a new design pack to organize your inspiration items.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="pack-name">Pack Name</Label>
+              <Input
+                id="pack-name"
+                placeholder="e.g., Spring Theme, Math Worksheets"
+                value={newPackName}
+                onChange={(e) => setNewPackName(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleCreatePack()}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsCreateDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleCreatePack} disabled={!newPackName.trim()}>
+              Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+interface DesignPackCardProps {
+  pack: DesignPack;
+  isExpanded: boolean;
+  isSelected: boolean;
+  onToggleExpand: () => void;
+  onSelect: () => void;
+  onDelete: () => void;
+  onAddUrl: () => void;
+  onRemoveItem: (itemId: string) => void;
+  onDrop: (e: React.DragEvent) => void;
+  onDragOver: (e: React.DragEvent) => void;
+}
+
+function DesignPackCard({
+  pack,
+  isExpanded,
+  isSelected,
+  onToggleExpand,
+  onSelect,
+  onDelete,
+  onAddUrl,
+  onRemoveItem,
+  onDrop,
+  onDragOver,
+}: DesignPackCardProps) {
+  return (
+    <Collapsible open={isExpanded} onOpenChange={onToggleExpand}>
+      <div
+        className={cn(
+          "rounded-lg border transition-colors",
+          isSelected && "border-primary bg-primary/5"
+        )}
+      >
+        <div className="flex items-center gap-2 p-2">
+          <CollapsibleTrigger asChild>
+            <Button variant="ghost" size="icon" className="h-6 w-6">
+              {isExpanded ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronRight className="h-4 w-4" />
+              )}
+            </Button>
+          </CollapsibleTrigger>
+
+          <div
+            className="flex-1 flex items-center gap-2 cursor-pointer"
+            onClick={onSelect}
+          >
+            <Package className="h-4 w-4 text-muted-foreground" />
+            <span className="text-sm font-medium truncate">{pack.name}</span>
+            <span className="text-xs text-muted-foreground">
+              ({pack.items.length})
+            </span>
+          </div>
+
+          {isSelected && (
+            <Check className="h-4 w-4 text-primary" />
+          )}
+
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 opacity-50 hover:opacity-100"
+            onClick={onAddUrl}
+            title="Add URL"
+          >
+            <Plus className="h-3 w-3" />
+          </Button>
+
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 opacity-50 hover:opacity-100 text-destructive hover:text-destructive"
+            onClick={onDelete}
+            title="Delete Pack"
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        </div>
+
+        <CollapsibleContent>
+          <div
+            onDrop={onDrop}
+            onDragOver={onDragOver}
+            className={cn(
+              "border-t mx-2 mb-2 p-2 rounded border-dashed",
+              "hover:border-primary/50 hover:bg-primary/5 transition-colors"
+            )}
+          >
+            {pack.items.length === 0 ? (
+              <div className="text-center py-2">
+                <Upload className="h-4 w-4 mx-auto text-muted-foreground/50 mb-1" />
+                <p className="text-xs text-muted-foreground">
+                  Drop URLs, PDFs, or images
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-1">
+                {pack.items.map((item) => {
+                  const Icon = getIcon(item.type);
+                  return (
+                    <div
+                      key={item.itemId}
+                      className="flex items-center gap-2 p-1 rounded bg-secondary/50 group"
+                    >
+                      <Icon className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+                      <span className="text-xs truncate flex-1">{item.title}</span>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-5 w-5 opacity-0 group-hover:opacity-100 transition-opacity"
+                        onClick={() => onRemoveItem(item.itemId)}
+                      >
+                        <X className="h-2 w-2" />
+                      </Button>
+                    </div>
+                  );
+                })}
+                <p className="text-xs text-muted-foreground text-center pt-1">
+                  Drop more files here
+                </p>
+              </div>
+            )}
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+}

--- a/src/components/design-packs/index.ts
+++ b/src/components/design-packs/index.ts
@@ -1,0 +1,1 @@
+export { DesignPacksPanel } from "./DesignPacksPanel";

--- a/src/components/layout/MainContent.tsx
+++ b/src/components/layout/MainContent.tsx
@@ -3,10 +3,11 @@ import { useProjectStore } from "@/stores/projectStore";
 import { ProjectPreview } from "@/components/preview/ProjectPreview";
 import { WelcomeScreen } from "./WelcomeScreen";
 import { TodayView, LearningPathView } from "@/components/learning-path";
+import { LibraryView } from "@/components/library";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { CalendarDays, Map, FolderOpen } from "lucide-react";
+import { CalendarDays, Map, FolderOpen, BookOpen } from "lucide-react";
 
-type MainTab = "today" | "learning-path" | "projects";
+type MainTab = "today" | "learning-path" | "library" | "projects";
 
 export function MainContent() {
   const [activeTab, setActiveTab] = useState<MainTab>("today");
@@ -40,6 +41,13 @@ export function MainContent() {
               Learning Path
             </TabsTrigger>
             <TabsTrigger
+              value="library"
+              className="data-[state=active]:bg-primary/10 data-[state=active]:text-primary gap-2"
+            >
+              <BookOpen className="h-4 w-4" />
+              Library
+            </TabsTrigger>
+            <TabsTrigger
               value="projects"
               className="data-[state=active]:bg-primary/10 data-[state=active]:text-primary gap-2"
             >
@@ -58,6 +66,7 @@ export function MainContent() {
         {activeTab === "learning-path" && (
           <LearningPathView initialSubject={selectedSubject} />
         )}
+        {activeTab === "library" && <LibraryView />}
         {activeTab === "projects" && (
           currentProject ? (
             <ProjectPreview project={currentProject} />

--- a/src/components/library/ArtifactCard.tsx
+++ b/src/components/library/ArtifactCard.tsx
@@ -1,0 +1,193 @@
+import { FileText, BookOpen, CheckSquare, ClipboardList, Eye, Printer, Trash2 } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { MoreHorizontal } from "lucide-react";
+import type { LocalArtifact, ArtifactType, Grade } from "@/types";
+import { getArtifactTypeLabel } from "@/types";
+
+interface ArtifactCardProps {
+  artifact: Omit<LocalArtifact, "htmlContent">;
+  onView: (artifactId: string) => void;
+  onPrint: (artifactId: string) => void;
+  onDelete: (artifactId: string) => void;
+}
+
+const ARTIFACT_ICONS: Record<ArtifactType, typeof FileText> = {
+  student_page: FileText,
+  teacher_script: BookOpen,
+  answer_key: CheckSquare,
+  lesson_plan: ClipboardList,
+  print_pack: FileText,
+};
+
+const GRADE_COLORS: Record<Grade, string> = {
+  K: "bg-purple-100 text-purple-800",
+  "1": "bg-blue-100 text-blue-800",
+  "2": "bg-green-100 text-green-800",
+  "3": "bg-yellow-100 text-yellow-800",
+  "4": "bg-orange-100 text-orange-800",
+  "5": "bg-red-100 text-red-800",
+  "6": "bg-pink-100 text-pink-800",
+};
+
+export function ArtifactCard({ artifact, onView, onPrint, onDelete }: ArtifactCardProps) {
+  const Icon = ARTIFACT_ICONS[artifact.type] || FileText;
+  const gradeColor = GRADE_COLORS[artifact.grade] || "bg-gray-100 text-gray-800";
+
+  const formattedDate = new Date(artifact.createdAt).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  return (
+    <Card className="group hover:shadow-md transition-shadow">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-lg bg-primary/10">
+              <Icon className="h-5 w-5 text-primary" />
+            </div>
+            <div className="space-y-1">
+              <CardTitle className="text-sm font-medium line-clamp-2">
+                {artifact.title}
+              </CardTitle>
+              <p className="text-xs text-muted-foreground">{formattedDate}</p>
+            </div>
+          </div>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 opacity-0 group-hover:opacity-100 transition-opacity"
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => onView(artifact.artifactId)}>
+                <Eye className="h-4 w-4 mr-2" />
+                View
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onPrint(artifact.artifactId)}>
+                <Printer className="h-4 w-4 mr-2" />
+                Print
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={() => onDelete(artifact.artifactId)}
+                className="text-destructive focus:text-destructive"
+              >
+                <Trash2 className="h-4 w-4 mr-2" />
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </CardHeader>
+
+      <CardContent className="pt-0">
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="outline" className={gradeColor}>
+            Grade {artifact.grade}
+          </Badge>
+          <Badge variant="secondary" className="text-xs">
+            {artifact.subject}
+          </Badge>
+          <Badge variant="outline" className="text-xs">
+            {getArtifactTypeLabel(artifact.type)}
+          </Badge>
+        </div>
+
+        {artifact.objectiveTags.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-1">
+            {artifact.objectiveTags.slice(0, 2).map((tag) => (
+              <Badge key={tag} variant="outline" className="text-xs font-mono">
+                {tag}
+              </Badge>
+            ))}
+            {artifact.objectiveTags.length > 2 && (
+              <Badge variant="outline" className="text-xs">
+                +{artifact.objectiveTags.length - 2} more
+              </Badge>
+            )}
+          </div>
+        )}
+
+        <Button
+          variant="ghost"
+          size="sm"
+          className="w-full mt-3"
+          onClick={() => onView(artifact.artifactId)}
+        >
+          <Eye className="h-4 w-4 mr-2" />
+          View
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+// Compact list variant
+export function ArtifactListItem({ artifact, onView, onPrint, onDelete }: ArtifactCardProps) {
+  const Icon = ARTIFACT_ICONS[artifact.type] || FileText;
+  const gradeColor = GRADE_COLORS[artifact.grade] || "bg-gray-100 text-gray-800";
+
+  const formattedDate = new Date(artifact.createdAt).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+
+  return (
+    <div className="flex items-center gap-4 p-3 rounded-lg border hover:bg-muted/50 transition-colors group">
+      <div className="p-2 rounded-lg bg-primary/10">
+        <Icon className="h-4 w-4 text-primary" />
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <p className="font-medium truncate">{artifact.title}</p>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <span>{artifact.subject}</span>
+          <span>•</span>
+          <span>{formattedDate}</span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Badge variant="outline" className={`${gradeColor} text-xs`}>
+          {artifact.grade}
+        </Badge>
+        <Badge variant="secondary" className="text-xs">
+          {getArtifactTypeLabel(artifact.type)}
+        </Badge>
+      </div>
+
+      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+        <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => onView(artifact.artifactId)}>
+          <Eye className="h-4 w-4" />
+        </Button>
+        <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => onPrint(artifact.artifactId)}>
+          <Printer className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 text-destructive hover:text-destructive"
+          onClick={() => onDelete(artifact.artifactId)}
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/library/LibraryFilters.tsx
+++ b/src/components/library/LibraryFilters.tsx
@@ -1,0 +1,232 @@
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useArtifactStore } from "@/stores/artifactStore";
+import { useUnifiedProjectStore } from "@/stores/unifiedProjectStore";
+import type { Grade, ArtifactType, LibraryFilters as LibraryFiltersType } from "@/types";
+import { getArtifactTypeLabel } from "@/types";
+import { SUBJECTS } from "@/types/learner";
+
+const GRADES: Grade[] = ["K", "1", "2", "3", "4", "5", "6"];
+
+const ARTIFACT_TYPES: ArtifactType[] = [
+  "student_page",
+  "teacher_script",
+  "answer_key",
+  "lesson_plan",
+  "print_pack",
+];
+
+interface LibraryFiltersProps {
+  onFilterChange?: () => void;
+}
+
+export function LibraryFilters({ onFilterChange }: LibraryFiltersProps) {
+  const { filters, setFilters, clearFilters } = useArtifactStore();
+  const { projects } = useUnifiedProjectStore();
+
+  const hasFilters =
+    filters.grades.length > 0 ||
+    filters.subjects.length > 0 ||
+    filters.types.length > 0 ||
+    filters.projects.length > 0;
+
+  const toggleGrade = (grade: Grade) => {
+    const newGrades = filters.grades.includes(grade)
+      ? filters.grades.filter((g) => g !== grade)
+      : [...filters.grades, grade];
+    setFilters({ grades: newGrades });
+    onFilterChange?.();
+  };
+
+  const toggleSubject = (subject: string) => {
+    const newSubjects = filters.subjects.includes(subject)
+      ? filters.subjects.filter((s) => s !== subject)
+      : [...filters.subjects, subject];
+    setFilters({ subjects: newSubjects });
+    onFilterChange?.();
+  };
+
+  const toggleType = (type: ArtifactType) => {
+    const newTypes = filters.types.includes(type)
+      ? filters.types.filter((t) => t !== type)
+      : [...filters.types, type];
+    setFilters({ types: newTypes });
+    onFilterChange?.();
+  };
+
+  const setProject = (projectId: string) => {
+    if (projectId === "all") {
+      setFilters({ projects: [] });
+    } else {
+      setFilters({ projects: [projectId] });
+    }
+    onFilterChange?.();
+  };
+
+  const handleClearFilters = () => {
+    clearFilters();
+    onFilterChange?.();
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Project Filter */}
+      <div>
+        <label className="text-sm font-medium mb-2 block">Project</label>
+        <Select
+          value={filters.projects[0] || "all"}
+          onValueChange={setProject}
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="All Projects" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Projects</SelectItem>
+            {projects.map((project) => (
+              <SelectItem key={project.projectId} value={project.projectId}>
+                {project.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Grade Filter */}
+      <div>
+        <label className="text-sm font-medium mb-2 block">Grade</label>
+        <div className="flex flex-wrap gap-2">
+          {GRADES.map((grade) => (
+            <Badge
+              key={grade}
+              variant={filters.grades.includes(grade) ? "default" : "outline"}
+              className="cursor-pointer"
+              onClick={() => toggleGrade(grade)}
+            >
+              {grade === "K" ? "K" : grade}
+            </Badge>
+          ))}
+        </div>
+      </div>
+
+      {/* Subject Filter */}
+      <div>
+        <label className="text-sm font-medium mb-2 block">Subject</label>
+        <div className="flex flex-wrap gap-2">
+          {SUBJECTS.map((subject) => (
+            <Badge
+              key={subject}
+              variant={filters.subjects.includes(subject) ? "default" : "outline"}
+              className="cursor-pointer"
+              onClick={() => toggleSubject(subject)}
+            >
+              {subject}
+            </Badge>
+          ))}
+        </div>
+      </div>
+
+      {/* Type Filter */}
+      <div>
+        <label className="text-sm font-medium mb-2 block">Type</label>
+        <div className="flex flex-wrap gap-2">
+          {ARTIFACT_TYPES.map((type) => (
+            <Badge
+              key={type}
+              variant={filters.types.includes(type) ? "default" : "outline"}
+              className="cursor-pointer text-xs"
+              onClick={() => toggleType(type)}
+            >
+              {getArtifactTypeLabel(type)}
+            </Badge>
+          ))}
+        </div>
+      </div>
+
+      {/* Clear Filters */}
+      {hasFilters && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="w-full"
+          onClick={handleClearFilters}
+        >
+          <X className="h-4 w-4 mr-2" />
+          Clear Filters
+        </Button>
+      )}
+    </div>
+  );
+}
+
+// Compact inline filter chips for display above results
+export function ActiveFilterChips() {
+  const { filters, setFilters } = useArtifactStore();
+  const { projects } = useUnifiedProjectStore();
+
+  const removeGrade = (grade: Grade) => {
+    setFilters({ grades: filters.grades.filter((g) => g !== grade) });
+  };
+
+  const removeSubject = (subject: string) => {
+    setFilters({ subjects: filters.subjects.filter((s) => s !== subject) });
+  };
+
+  const removeType = (type: ArtifactType) => {
+    setFilters({ types: filters.types.filter((t) => t !== type) });
+  };
+
+  const removeProject = (projectId: string) => {
+    setFilters({ projects: filters.projects.filter((p) => p !== projectId) });
+  };
+
+  const hasFilters =
+    filters.grades.length > 0 ||
+    filters.subjects.length > 0 ||
+    filters.types.length > 0 ||
+    filters.projects.length > 0;
+
+  if (!hasFilters) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2 mb-4">
+      {filters.projects.map((projectId) => {
+        const project = projects.find((p) => p.projectId === projectId);
+        return (
+          <Badge key={projectId} variant="secondary" className="gap-1">
+            {project?.name || "Unknown Project"}
+            <X
+              className="h-3 w-3 cursor-pointer"
+              onClick={() => removeProject(projectId)}
+            />
+          </Badge>
+        );
+      })}
+      {filters.grades.map((grade) => (
+        <Badge key={grade} variant="secondary" className="gap-1">
+          Grade {grade}
+          <X className="h-3 w-3 cursor-pointer" onClick={() => removeGrade(grade)} />
+        </Badge>
+      ))}
+      {filters.subjects.map((subject) => (
+        <Badge key={subject} variant="secondary" className="gap-1">
+          {subject}
+          <X className="h-3 w-3 cursor-pointer" onClick={() => removeSubject(subject)} />
+        </Badge>
+      ))}
+      {filters.types.map((type) => (
+        <Badge key={type} variant="secondary" className="gap-1">
+          {getArtifactTypeLabel(type)}
+          <X className="h-3 w-3 cursor-pointer" onClick={() => removeType(type)} />
+        </Badge>
+      ))}
+    </div>
+  );
+}

--- a/src/components/library/LibraryView.tsx
+++ b/src/components/library/LibraryView.tsx
@@ -1,0 +1,292 @@
+import { useEffect, useState } from "react";
+import { Search, Grid, List, SlidersHorizontal, BookOpen, Loader2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useArtifactStore, useFilteredArtifacts } from "@/stores/artifactStore";
+import { useUnifiedProjectStore } from "@/stores/unifiedProjectStore";
+import { ArtifactCard, ArtifactListItem } from "./ArtifactCard";
+import { LibraryFilters, ActiveFilterChips } from "./LibraryFilters";
+import { HTMLRenderer } from "@/components/preview/HTMLRenderer";
+import type { LibrarySortBy, LibraryViewMode, LocalArtifact } from "@/types";
+
+const SORT_OPTIONS: { value: LibrarySortBy; label: string }[] = [
+  { value: "date_desc", label: "Newest First" },
+  { value: "date_asc", label: "Oldest First" },
+  { value: "title_asc", label: "Title A-Z" },
+  { value: "title_desc", label: "Title Z-A" },
+  { value: "grade", label: "By Grade" },
+];
+
+export function LibraryView() {
+  const {
+    isLoading,
+    error,
+    viewMode,
+    sortBy,
+    searchQuery,
+    currentArtifact,
+    loadArtifacts,
+    loadArtifact,
+    deleteArtifact,
+    setViewMode,
+    setSortBy,
+    setSearchQuery,
+    setCurrentArtifact,
+  } = useArtifactStore();
+
+  const { loadProjects } = useUnifiedProjectStore();
+  const filteredArtifacts = useFilteredArtifacts();
+
+  const [isFilterSheetOpen, setIsFilterSheetOpen] = useState(false);
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+
+  // Load artifacts and projects on mount
+  useEffect(() => {
+    loadArtifacts();
+    loadProjects();
+  }, [loadArtifacts, loadProjects]);
+
+  const handleView = async (artifactId: string) => {
+    await loadArtifact(artifactId);
+    setIsPreviewOpen(true);
+  };
+
+  const handlePrint = async (artifactId: string) => {
+    const artifact = await loadArtifact(artifactId);
+    if (!artifact) return;
+
+    const printWindow = window.open("", "_blank");
+    if (!printWindow) return;
+
+    printWindow.document.write(`
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <title>${artifact.title}</title>
+        <style>
+          body {
+            font-family: "Arial", sans-serif;
+            line-height: 1.6;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            color: #333;
+          }
+          h1 { font-size: 24px; margin-bottom: 16px; }
+          h2 { font-size: 20px; margin-top: 24px; margin-bottom: 12px; }
+          h3 { font-size: 16px; margin-top: 16px; margin-bottom: 8px; }
+          p { margin-bottom: 12px; }
+          ul, ol { margin-bottom: 12px; padding-left: 24px; }
+          table { border-collapse: collapse; width: 100%; margin-bottom: 16px; }
+          th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+          th { background-color: #f5f5f5; }
+        </style>
+      </head>
+      <body>
+        ${artifact.htmlContent}
+      </body>
+      </html>
+    `);
+
+    printWindow.document.close();
+    printWindow.focus();
+    printWindow.print();
+  };
+
+  const handleDelete = async (artifactId: string) => {
+    if (confirm("Are you sure you want to delete this item?")) {
+      await deleteArtifact(artifactId);
+    }
+  };
+
+  const handleClosePreview = () => {
+    setIsPreviewOpen(false);
+    setCurrentArtifact(null);
+  };
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-center p-8">
+        <p className="text-destructive mb-4">{error}</p>
+        <Button onClick={() => loadArtifacts()}>Try Again</Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Library</h1>
+          <p className="text-muted-foreground">
+            Browse all your generated teaching materials
+          </p>
+        </div>
+      </div>
+
+      {/* Search and Controls */}
+      <div className="flex items-center gap-4 mb-4">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search materials..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+
+        <Select value={sortBy} onValueChange={(v) => setSortBy(v as LibrarySortBy)}>
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder="Sort by" />
+          </SelectTrigger>
+          <SelectContent>
+            {SORT_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <div className="flex items-center border rounded-lg">
+          <Button
+            variant={viewMode === "grid" ? "secondary" : "ghost"}
+            size="icon"
+            className="rounded-r-none"
+            onClick={() => setViewMode("grid")}
+          >
+            <Grid className="h-4 w-4" />
+          </Button>
+          <Button
+            variant={viewMode === "list" ? "secondary" : "ghost"}
+            size="icon"
+            className="rounded-l-none"
+            onClick={() => setViewMode("list")}
+          >
+            <List className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <Sheet open={isFilterSheetOpen} onOpenChange={setIsFilterSheetOpen}>
+          <SheetTrigger asChild>
+            <Button variant="outline" size="icon">
+              <SlidersHorizontal className="h-4 w-4" />
+            </Button>
+          </SheetTrigger>
+          <SheetContent>
+            <SheetHeader>
+              <SheetTitle>Filters</SheetTitle>
+              <SheetDescription>
+                Filter your library by project, grade, subject, or type
+              </SheetDescription>
+            </SheetHeader>
+            <div className="mt-6">
+              <LibraryFilters onFilterChange={() => setIsFilterSheetOpen(false)} />
+            </div>
+          </SheetContent>
+        </Sheet>
+      </div>
+
+      {/* Active Filters */}
+      <ActiveFilterChips />
+
+      {/* Loading State */}
+      {isLoading && (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {/* Empty State */}
+      {!isLoading && filteredArtifacts.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <div className="p-4 rounded-full bg-muted mb-4">
+            <BookOpen className="h-8 w-8 text-muted-foreground" />
+          </div>
+          <h3 className="font-medium mb-2">No materials found</h3>
+          <p className="text-muted-foreground text-sm max-w-md">
+            {searchQuery
+              ? "Try adjusting your search or filters"
+              : "Generate some teaching materials to see them here"}
+          </p>
+        </div>
+      )}
+
+      {/* Results */}
+      {!isLoading && filteredArtifacts.length > 0 && (
+        <>
+          <p className="text-sm text-muted-foreground mb-4">
+            {filteredArtifacts.length} item{filteredArtifacts.length !== 1 ? "s" : ""}
+          </p>
+
+          {viewMode === "grid" ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+              {filteredArtifacts.map((artifact) => (
+                <ArtifactCard
+                  key={artifact.artifactId}
+                  artifact={artifact}
+                  onView={handleView}
+                  onPrint={handlePrint}
+                  onDelete={handleDelete}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {filteredArtifacts.map((artifact) => (
+                <ArtifactListItem
+                  key={artifact.artifactId}
+                  artifact={artifact}
+                  onView={handleView}
+                  onPrint={handlePrint}
+                  onDelete={handleDelete}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Preview Dialog */}
+      <Dialog open={isPreviewOpen} onOpenChange={handleClosePreview}>
+        <DialogContent className="max-w-4xl h-[80vh] flex flex-col">
+          <DialogHeader>
+            <DialogTitle>{currentArtifact?.title || "Preview"}</DialogTitle>
+          </DialogHeader>
+          <div className="flex-1 overflow-auto border rounded-lg">
+            {currentArtifact?.htmlContent ? (
+              <HTMLRenderer html={currentArtifact.htmlContent} />
+            ) : (
+              <div className="flex items-center justify-center h-full text-muted-foreground">
+                No content available
+              </div>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/library/index.ts
+++ b/src/components/library/index.ts
@@ -1,0 +1,3 @@
+export { LibraryView } from "./LibraryView";
+export { ArtifactCard, ArtifactListItem } from "./ArtifactCard";
+export { LibraryFilters, ActiveFilterChips } from "./LibraryFilters";

--- a/src/components/preview/PreviewTabs.tsx
+++ b/src/components/preview/PreviewTabs.tsx
@@ -1,18 +1,34 @@
 import { useState } from "react";
-import { FileText, BookOpen, CheckSquare, Download, Printer, Loader2 } from "lucide-react";
+import { FileText, BookOpen, CheckSquare, Download, Printer, Loader2, ClipboardList, Package } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { HTMLRenderer } from "./HTMLRenderer";
 import { generatePdf } from "@/services/generation-api";
 import { useAuthStore } from "@/stores/authStore";
+import type { PreviewTabId } from "@/types";
 
+// Legacy tab type for backwards compatibility
 export type PreviewTab = "worksheet" | "lesson_plan" | "answer_key";
 
+// New standardized tab type (Issue #20)
+export type StandardizedPreviewTab = PreviewTabId;
+
+// Legacy props interface (backwards compatible)
 interface PreviewTabsProps {
   worksheetHtml: string;
   lessonPlanHtml: string;
   answerKeyHtml: string;
   projectTitle: string;
+}
+
+// New standardized props interface (Issue #20)
+interface StandardizedPreviewTabsProps {
+  studentPageHtml?: string;
+  teacherScriptHtml?: string;
+  answerKeyHtml?: string;
+  lessonPlanHtml?: string;
+  projectTitle: string;
+  showPrintPack?: boolean;
 }
 
 export function PreviewTabs({
@@ -185,4 +201,280 @@ export function PreviewTabs({
       </Tabs>
     </div>
   );
+}
+
+/**
+ * Standardized Preview Tabs component (Issue #20)
+ * Follows the new tab structure: Student Page, Teacher Script, Answer Key, Lesson Plan, Print Pack
+ */
+export function StandardizedPreviewTabs({
+  studentPageHtml,
+  teacherScriptHtml,
+  answerKeyHtml,
+  lessonPlanHtml,
+  projectTitle,
+  showPrintPack = true,
+}: StandardizedPreviewTabsProps) {
+  const [activeTab, setActiveTab] = useState<StandardizedPreviewTab>("student_page");
+  const [isDownloading, setIsDownloading] = useState(false);
+  const { session } = useAuthStore();
+
+  // Build tabs based on available content
+  const tabs: Array<{
+    id: StandardizedPreviewTab;
+    label: string;
+    icon: typeof FileText;
+    content: string | undefined;
+  }> = [
+    {
+      id: "student_page",
+      label: "Student Page",
+      icon: FileText,
+      content: studentPageHtml,
+    },
+    {
+      id: "teacher_script",
+      label: "Teacher Script",
+      icon: BookOpen,
+      content: teacherScriptHtml,
+    },
+    {
+      id: "answer_key",
+      label: "Answer Key",
+      icon: CheckSquare,
+      content: answerKeyHtml,
+    },
+    {
+      id: "lesson_plan",
+      label: "Lesson Plan",
+      icon: ClipboardList,
+      content: lessonPlanHtml,
+    },
+  ];
+
+  // Add print pack if enabled and there's any content
+  if (showPrintPack) {
+    const hasAnyContent = studentPageHtml || teacherScriptHtml || answerKeyHtml || lessonPlanHtml;
+    tabs.push({
+      id: "print_pack",
+      label: "Print Pack",
+      icon: Package,
+      content: hasAnyContent ? "print_pack" : undefined,
+    });
+  }
+
+  // Find first available tab
+  const firstAvailableTab = tabs.find((t) => t.content)?.id || "student_page";
+
+  // Auto-select first available tab if current tab has no content
+  const currentTab = tabs.find((t) => t.id === activeTab);
+  const effectiveActiveTab = currentTab?.content ? activeTab : firstAvailableTab;
+
+  const currentContent = activeTab === "print_pack"
+    ? buildPrintPackContent(studentPageHtml, teacherScriptHtml, answerKeyHtml, lessonPlanHtml, projectTitle)
+    : tabs.find((t) => t.id === activeTab)?.content || "";
+
+  const handlePrint = () => {
+    const printWindow = window.open("", "_blank");
+    if (!printWindow) return;
+
+    const tabLabel = tabs.find((t) => t.id === activeTab)?.label || "";
+    const title = `${projectTitle} - ${tabLabel}`;
+
+    printWindow.document.write(`
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <title>${title}</title>
+        <style>
+          body {
+            font-family: "Arial", sans-serif;
+            line-height: 1.6;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            color: #333;
+          }
+          h1 { font-size: 24px; margin-bottom: 16px; }
+          h2 { font-size: 20px; margin-top: 24px; margin-bottom: 12px; }
+          h3 { font-size: 16px; margin-top: 16px; margin-bottom: 8px; }
+          p { margin-bottom: 12px; }
+          ul, ol { margin-bottom: 12px; padding-left: 24px; }
+          table { border-collapse: collapse; width: 100%; margin-bottom: 16px; }
+          th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+          th { background-color: #f5f5f5; }
+          .question { margin-bottom: 20px; }
+          .answer-line { border-bottom: 1px solid #999; height: 24px; margin: 8px 0; }
+          .page-break { page-break-after: always; }
+          .section-divider { margin: 32px 0; border-top: 2px solid #333; padding-top: 16px; }
+          @media print {
+            .page-break { page-break-after: always; }
+          }
+        </style>
+      </head>
+      <body>
+        ${currentContent}
+      </body>
+      </html>
+    `);
+
+    printWindow.document.close();
+    printWindow.focus();
+    printWindow.print();
+  };
+
+  const handleDownloadPdf = async () => {
+    if (!session?.access_token || !currentContent) return;
+
+    setIsDownloading(true);
+
+    try {
+      const blob = await generatePdf(currentContent, session.access_token);
+      const tabLabel = tabs.find((t) => t.id === activeTab)?.label || "";
+      const filename = `${projectTitle} - ${tabLabel}.pdf`;
+
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error("PDF download failed:", error);
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  return (
+    <div className="h-full flex flex-col">
+      <Tabs
+        value={effectiveActiveTab}
+        onValueChange={(v) => setActiveTab(v as StandardizedPreviewTab)}
+        className="flex-1 flex flex-col"
+      >
+        <div className="flex items-center justify-between border-b px-4 py-2 bg-muted/30">
+          <TabsList className="bg-transparent h-auto p-0 gap-1 flex-wrap">
+            {tabs.map((tab) => (
+              <TabsTrigger
+                key={tab.id}
+                value={tab.id}
+                disabled={!tab.content}
+                className="gap-2 data-[state=active]:bg-background"
+              >
+                <tab.icon className="h-4 w-4" />
+                {tab.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handlePrint}
+              disabled={!currentContent}
+            >
+              <Printer className="h-4 w-4 mr-1" />
+              Print
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleDownloadPdf}
+              disabled={!currentContent || isDownloading}
+            >
+              {isDownloading ? (
+                <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+              ) : (
+                <Download className="h-4 w-4 mr-1" />
+              )}
+              PDF
+            </Button>
+          </div>
+        </div>
+
+        {tabs.map((tab) => (
+          <TabsContent
+            key={tab.id}
+            value={tab.id}
+            className="flex-1 mt-0 data-[state=active]:flex data-[state=active]:flex-col"
+          >
+            {tab.content ? (
+              tab.id === "print_pack" ? (
+                <HTMLRenderer html={buildPrintPackContent(studentPageHtml, teacherScriptHtml, answerKeyHtml, lessonPlanHtml, projectTitle)} />
+              ) : (
+                <HTMLRenderer html={tab.content} />
+              )
+            ) : (
+              <div className="flex-1 flex items-center justify-center text-muted-foreground">
+                No content available
+              </div>
+            )}
+          </TabsContent>
+        ))}
+      </Tabs>
+    </div>
+  );
+}
+
+/**
+ * Build combined print pack HTML from all available content
+ */
+function buildPrintPackContent(
+  studentPageHtml?: string,
+  teacherScriptHtml?: string,
+  answerKeyHtml?: string,
+  lessonPlanHtml?: string,
+  projectTitle?: string
+): string {
+  const sections: string[] = [];
+
+  if (studentPageHtml) {
+    sections.push(`
+      <div class="section">
+        <h2 class="section-title">Student Page</h2>
+        ${studentPageHtml}
+      </div>
+      <div class="page-break"></div>
+    `);
+  }
+
+  if (teacherScriptHtml) {
+    sections.push(`
+      <div class="section">
+        <h2 class="section-title">Teacher Script</h2>
+        ${teacherScriptHtml}
+      </div>
+      <div class="page-break"></div>
+    `);
+  }
+
+  if (answerKeyHtml) {
+    sections.push(`
+      <div class="section">
+        <h2 class="section-title">Answer Key</h2>
+        ${answerKeyHtml}
+      </div>
+      <div class="page-break"></div>
+    `);
+  }
+
+  if (lessonPlanHtml) {
+    sections.push(`
+      <div class="section">
+        <h2 class="section-title">Lesson Plan</h2>
+        ${lessonPlanHtml}
+      </div>
+    `);
+  }
+
+  return `
+    <div class="print-pack">
+      <h1 class="print-pack-title">${projectTitle || "Teaching Materials"}</h1>
+      ${sections.join("\n")}
+    </div>
+  `;
 }

--- a/src/lib/migration.ts
+++ b/src/lib/migration.ts
@@ -1,0 +1,335 @@
+/**
+ * Data Migration Utilities (Issue #20)
+ *
+ * Provides migration functions to convert existing data to the new unified format:
+ * - Projects to UnifiedProject
+ * - Inspiration items to Design Packs
+ * - Project versions to Artifacts
+ */
+
+import type {
+  Project,
+  ProjectVersion,
+  InspirationItem,
+  UnifiedProject,
+  DesignPack,
+  LocalArtifact,
+  ArtifactType,
+  MigrationStatus,
+  gradeToGradeBand,
+} from "@/types";
+
+const MIGRATION_KEY = "ta-migration-status";
+const CURRENT_MIGRATION_VERSION = 1;
+
+/**
+ * Check if migration is needed
+ */
+export function isMigrationNeeded(): boolean {
+  const status = getMigrationStatus();
+  return status === null || status.version < CURRENT_MIGRATION_VERSION;
+}
+
+/**
+ * Get current migration status
+ */
+export function getMigrationStatus(): MigrationStatus | null {
+  const stored = localStorage.getItem(MIGRATION_KEY);
+  if (!stored) return null;
+  try {
+    return JSON.parse(stored);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save migration status
+ */
+export function saveMigrationStatus(status: MigrationStatus): void {
+  localStorage.setItem(MIGRATION_KEY, JSON.stringify(status));
+}
+
+/**
+ * Map old artifact types to new unified types
+ */
+export function mapLegacyArtifactType(legacyType: string): ArtifactType {
+  switch (legacyType) {
+    case "worksheet":
+    case "worksheetHtml":
+    case "student_activity":
+    case "studentActivityHtml":
+      return "student_page";
+    case "lesson_plan":
+    case "lessonPlanHtml":
+      return "lesson_plan";
+    case "answer_key":
+    case "answerKeyHtml":
+      return "answer_key";
+    case "teacher_script":
+    case "teacherScriptHtml":
+      return "teacher_script";
+    default:
+      return "student_page";
+  }
+}
+
+/**
+ * Convert a legacy Project to UnifiedProject
+ */
+export function migrateProject(project: Project): UnifiedProject {
+  const now = new Date().toISOString();
+  const { gradeToGradeBand } = require("@/types");
+
+  return {
+    projectId: project.id,
+    type: "quick_create", // Legacy projects are quick create
+    name: project.title,
+    description: project.description || undefined,
+    grade: project.grade,
+    gradeBand: gradeToGradeBand(project.grade),
+    subjectFocus: [project.subject],
+    artifactIds: [], // Will be populated during artifact migration
+    status: project.status,
+    lastActivityDate: project.updatedAt?.toISOString() || now,
+    createdAt: project.createdAt?.toISOString() || now,
+    updatedAt: project.updatedAt?.toISOString() || now,
+  };
+}
+
+/**
+ * Convert a ProjectVersion to LocalArtifacts
+ */
+export function migrateProjectVersion(
+  version: ProjectVersion,
+  project: Project
+): LocalArtifact[] {
+  const artifacts: LocalArtifact[] = [];
+  const createdAt = version.createdAt?.toISOString() || new Date().toISOString();
+
+  // Migrate worksheet/student page
+  if (version.worksheetHtml) {
+    artifacts.push({
+      artifactId: `${version.id}-student_page`,
+      projectId: version.projectId,
+      jobId: version.id,
+      type: "student_page",
+      title: `${project.title} - Student Page`,
+      htmlContent: version.worksheetHtml,
+      grade: project.grade,
+      subject: project.subject,
+      objectiveTags: [], // Legacy projects don't have objective tags
+      createdAt,
+    });
+  }
+
+  // Migrate student activity (if different from worksheet)
+  if (version.studentActivityHtml && version.studentActivityHtml !== version.worksheetHtml) {
+    artifacts.push({
+      artifactId: `${version.id}-student_activity`,
+      projectId: version.projectId,
+      jobId: version.id,
+      type: "student_page",
+      title: `${project.title} - Student Activity`,
+      htmlContent: version.studentActivityHtml,
+      grade: project.grade,
+      subject: project.subject,
+      objectiveTags: [],
+      createdAt,
+    });
+  }
+
+  // Migrate teacher script
+  if (version.teacherScriptHtml) {
+    artifacts.push({
+      artifactId: `${version.id}-teacher_script`,
+      projectId: version.projectId,
+      jobId: version.id,
+      type: "teacher_script",
+      title: `${project.title} - Teacher Script`,
+      htmlContent: version.teacherScriptHtml,
+      grade: project.grade,
+      subject: project.subject,
+      objectiveTags: [],
+      createdAt,
+    });
+  }
+
+  // Migrate lesson plan
+  if (version.lessonPlanHtml) {
+    artifacts.push({
+      artifactId: `${version.id}-lesson_plan`,
+      projectId: version.projectId,
+      jobId: version.id,
+      type: "lesson_plan",
+      title: `${project.title} - Lesson Plan`,
+      htmlContent: version.lessonPlanHtml,
+      grade: project.grade,
+      subject: project.subject,
+      objectiveTags: [],
+      createdAt,
+    });
+  }
+
+  // Migrate answer key
+  if (version.answerKeyHtml) {
+    artifacts.push({
+      artifactId: `${version.id}-answer_key`,
+      projectId: version.projectId,
+      jobId: version.id,
+      type: "answer_key",
+      title: `${project.title} - Answer Key`,
+      htmlContent: version.answerKeyHtml,
+      grade: project.grade,
+      subject: project.subject,
+      objectiveTags: [],
+      createdAt,
+    });
+  }
+
+  return artifacts;
+}
+
+/**
+ * Convert legacy InspirationItems to a DesignPack
+ */
+export function migrateInspirationItems(
+  items: InspirationItem[],
+  packName: string = "Imported Inspiration"
+): DesignPack {
+  const now = new Date().toISOString();
+
+  return {
+    packId: crypto.randomUUID(),
+    name: packName,
+    description: "Migrated from legacy design inspiration",
+    items: items.map((item) => ({
+      itemId: item.id.startsWith("local_") ? crypto.randomUUID() : item.id,
+      type: item.type,
+      title: item.title,
+      sourceUrl: item.sourceUrl,
+      content: item.content,
+      storagePath: item.storagePath,
+    })),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/**
+ * Run full migration (call during app initialization if needed)
+ */
+export async function runMigration(
+  legacyProjects: Project[],
+  saveProject: (project: UnifiedProject) => Promise<void>,
+  saveArtifact: (artifact: LocalArtifact) => Promise<void>,
+  saveDesignPack: (pack: DesignPack) => Promise<void>
+): Promise<MigrationStatus> {
+  const status: MigrationStatus = {
+    version: CURRENT_MIGRATION_VERSION,
+    lastMigrated: new Date().toISOString(),
+    migratedEntities: {
+      projects: 0,
+      inspiration: 0,
+      artifacts: 0,
+    },
+  };
+
+  // Migrate each project
+  for (const project of legacyProjects) {
+    try {
+      // Convert project
+      const unifiedProject = migrateProject(project);
+
+      // Convert inspiration items to design pack if any
+      if (project.inspiration && project.inspiration.length > 0) {
+        const pack = migrateInspirationItems(
+          project.inspiration,
+          `${project.title} Inspiration`
+        );
+        await saveDesignPack(pack);
+        unifiedProject.defaultDesignPackId = pack.packId;
+        status.migratedEntities.inspiration += project.inspiration.length;
+      }
+
+      // Convert latest version to artifacts
+      if (project.latestVersion) {
+        const artifacts = migrateProjectVersion(project.latestVersion, project);
+        for (const artifact of artifacts) {
+          await saveArtifact(artifact);
+          unifiedProject.artifactIds.push(artifact.artifactId);
+          status.migratedEntities.artifacts++;
+        }
+      }
+
+      // Save the unified project
+      await saveProject(unifiedProject);
+      status.migratedEntities.projects++;
+    } catch (error) {
+      console.error(`Failed to migrate project ${project.id}:`, error);
+    }
+  }
+
+  // Save migration status
+  saveMigrationStatus(status);
+
+  return status;
+}
+
+/**
+ * Extract objective tags from content (basic heuristic)
+ * This is a fallback for content without explicit objective tags
+ */
+export function inferObjectiveTags(
+  content: string,
+  grade: string,
+  subject: string
+): string[] {
+  const tags: string[] = [];
+
+  // Common patterns to detect
+  const patterns: Record<string, RegExp[]> = {
+    MATH: {
+      COUNT: [/count/i, /number.*1.*20/i, /counting/i],
+      ADD: [/add/i, /addition/i, /sum/i, /plus/i],
+      SUB: [/subtract/i, /minus/i, /take away/i],
+      MULT: [/multiply/i, /times/i, /multiplication/i],
+      DIV: [/divide/i, /division/i],
+      SHAPES: [/shape/i, /circle/i, /square/i, /triangle/i],
+      MEASURE: [/measure/i, /length/i, /weight/i, /time/i],
+    },
+    READING: {
+      PHONICS: [/phonics/i, /sound/i, /letter.*sound/i],
+      CVC: [/cvc/i, /consonant.*vowel/i],
+      SIGHT: [/sight word/i],
+      COMPREH: [/comprehension/i, /main idea/i, /character/i],
+      FLUENCY: [/fluency/i, /read.*aloud/i],
+    },
+    WRITING: {
+      SENTENCE: [/sentence/i, /capital/i, /period/i],
+      PARAGRAPH: [/paragraph/i],
+      STORY: [/story/i, /narrative/i],
+    },
+    SCIENCE: {
+      LIFE: [/plant/i, /animal/i, /living/i],
+      EARTH: [/weather/i, /season/i, /rock/i],
+      PHYSICAL: [/magnet/i, /force/i, /matter/i],
+    },
+  };
+
+  const subjectKey = subject.toUpperCase().replace(/\s+/g, "_");
+  const subjectPatterns = patterns[subjectKey];
+
+  if (subjectPatterns) {
+    for (const [domain, domainPatterns] of Object.entries(subjectPatterns)) {
+      for (const pattern of domainPatterns) {
+        if (pattern.test(content)) {
+          tags.push(`${grade}.${subjectKey}.${domain}`);
+          break; // Only add one tag per domain
+        }
+      }
+    }
+  }
+
+  return tags;
+}

--- a/src/services/design-pack-storage.ts
+++ b/src/services/design-pack-storage.ts
@@ -1,0 +1,232 @@
+import { invoke } from "@tauri-apps/api/core";
+import { isTauriContext } from "./tauri-bridge";
+import type {
+  DesignPack,
+  DesignPackItem,
+  CreateDesignPackData,
+} from "@/types";
+
+// ============================================
+// Design Pack Functions
+// ============================================
+
+/**
+ * Get all design packs
+ */
+export async function getDesignPacks(): Promise<DesignPack[]> {
+  if (!isTauriContext()) {
+    // Browser fallback - use localStorage
+    const stored = localStorage.getItem("design-packs");
+    return stored ? JSON.parse(stored) : [];
+  }
+
+  const result = await invoke<string>("get_design_packs");
+  return JSON.parse(result);
+}
+
+/**
+ * Get a specific design pack by ID
+ */
+export async function getDesignPack(packId: string): Promise<DesignPack | null> {
+  if (!isTauriContext()) {
+    // Browser fallback
+    const packs = await getDesignPacks();
+    return packs.find((p) => p.packId === packId) || null;
+  }
+
+  try {
+    const result = await invoke<string>("get_design_pack", { packId });
+    return JSON.parse(result);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save a design pack (create or update)
+ */
+export async function saveDesignPack(pack: DesignPack): Promise<void> {
+  if (!isTauriContext()) {
+    // Browser fallback
+    const packs = await getDesignPacks();
+    const index = packs.findIndex((p) => p.packId === pack.packId);
+    if (index >= 0) {
+      packs[index] = pack;
+    } else {
+      packs.push(pack);
+    }
+    localStorage.setItem("design-packs", JSON.stringify(packs));
+    return;
+  }
+
+  await invoke("save_design_pack", {
+    pack: JSON.stringify(pack),
+  });
+}
+
+/**
+ * Create a new design pack
+ */
+export async function createDesignPack(data: CreateDesignPackData): Promise<DesignPack> {
+  const now = new Date().toISOString();
+  const pack: DesignPack = {
+    packId: crypto.randomUUID(),
+    name: data.name,
+    description: data.description,
+    items: data.items || [],
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  await saveDesignPack(pack);
+  return pack;
+}
+
+/**
+ * Update a design pack
+ */
+export async function updateDesignPack(
+  packId: string,
+  updates: Partial<Omit<DesignPack, "packId" | "createdAt">>
+): Promise<DesignPack> {
+  const pack = await getDesignPack(packId);
+  if (!pack) {
+    throw new Error(`Design pack not found: ${packId}`);
+  }
+
+  const updated: DesignPack = {
+    ...pack,
+    ...updates,
+    updatedAt: new Date().toISOString(),
+  };
+
+  await saveDesignPack(updated);
+  return updated;
+}
+
+/**
+ * Delete a design pack
+ */
+export async function deleteDesignPack(packId: string): Promise<void> {
+  if (!isTauriContext()) {
+    // Browser fallback
+    const packs = await getDesignPacks();
+    const filtered = packs.filter((p) => p.packId !== packId);
+    localStorage.setItem("design-packs", JSON.stringify(filtered));
+    return;
+  }
+
+  await invoke("delete_design_pack", { packId });
+}
+
+/**
+ * Add an item to a design pack
+ */
+export async function addItemToDesignPack(
+  packId: string,
+  item: Omit<DesignPackItem, "itemId">
+): Promise<DesignPackItem> {
+  const pack = await getDesignPack(packId);
+  if (!pack) {
+    throw new Error(`Design pack not found: ${packId}`);
+  }
+
+  const newItem: DesignPackItem = {
+    ...item,
+    itemId: crypto.randomUUID(),
+  };
+
+  pack.items.push(newItem);
+  pack.updatedAt = new Date().toISOString();
+
+  await saveDesignPack(pack);
+  return newItem;
+}
+
+/**
+ * Remove an item from a design pack
+ */
+export async function removeItemFromDesignPack(
+  packId: string,
+  itemId: string
+): Promise<void> {
+  const pack = await getDesignPack(packId);
+  if (!pack) {
+    throw new Error(`Design pack not found: ${packId}`);
+  }
+
+  pack.items = pack.items.filter((i) => i.itemId !== itemId);
+  pack.updatedAt = new Date().toISOString();
+
+  await saveDesignPack(pack);
+}
+
+/**
+ * Reorder items in a design pack
+ */
+export async function reorderDesignPackItems(
+  packId: string,
+  itemIds: string[]
+): Promise<void> {
+  const pack = await getDesignPack(packId);
+  if (!pack) {
+    throw new Error(`Design pack not found: ${packId}`);
+  }
+
+  // Create a map of items by ID
+  const itemMap = new Map(pack.items.map((i) => [i.itemId, i]));
+
+  // Reorder based on itemIds array
+  const reorderedItems: DesignPackItem[] = [];
+  for (const id of itemIds) {
+    const item = itemMap.get(id);
+    if (item) {
+      reorderedItems.push(item);
+      itemMap.delete(id);
+    }
+  }
+
+  // Add any remaining items not in the itemIds array
+  for (const item of itemMap.values()) {
+    reorderedItems.push(item);
+  }
+
+  pack.items = reorderedItems;
+  pack.updatedAt = new Date().toISOString();
+
+  await saveDesignPack(pack);
+}
+
+/**
+ * Convert legacy inspiration items to a design pack
+ */
+export async function createDesignPackFromLegacyItems(
+  name: string,
+  legacyItems: Array<{
+    id: string;
+    type: "url" | "pdf" | "image" | "text";
+    title: string;
+    sourceUrl?: string;
+    content?: string;
+    storagePath?: string;
+  }>
+): Promise<DesignPack> {
+  const now = new Date().toISOString();
+  const pack: DesignPack = {
+    packId: crypto.randomUUID(),
+    name,
+    items: legacyItems.map((item) => ({
+      itemId: item.id.startsWith("local_") ? crypto.randomUUID() : item.id,
+      type: item.type,
+      title: item.title,
+      sourceUrl: item.sourceUrl,
+      content: item.content,
+      storagePath: item.storagePath,
+    })),
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  await saveDesignPack(pack);
+  return pack;
+}

--- a/src/services/library-storage.ts
+++ b/src/services/library-storage.ts
@@ -1,0 +1,279 @@
+import { invoke } from "@tauri-apps/api/core";
+import { isTauriContext } from "./tauri-bridge";
+import type {
+  LocalArtifact,
+  ArtifactSearchQuery,
+  LibraryIndex,
+} from "@/types";
+
+// ============================================
+// Library Index Functions
+// ============================================
+
+/**
+ * Get the library index (metadata for all artifacts)
+ */
+export async function getLibraryIndex(): Promise<LibraryIndex> {
+  if (!isTauriContext()) {
+    // Browser fallback - use localStorage
+    const stored = localStorage.getItem("library-index");
+    if (stored) return JSON.parse(stored);
+    return {
+      version: 1,
+      lastUpdated: new Date().toISOString(),
+      artifacts: [],
+    };
+  }
+
+  const result = await invoke<string>("get_library_index");
+  return JSON.parse(result);
+}
+
+/**
+ * Save the library index
+ */
+export async function saveLibraryIndex(index: LibraryIndex): Promise<void> {
+  if (!isTauriContext()) {
+    // Browser fallback
+    localStorage.setItem("library-index", JSON.stringify(index));
+    return;
+  }
+
+  await invoke("save_library_index", {
+    index: JSON.stringify(index),
+  });
+}
+
+// ============================================
+// Artifact Functions
+// ============================================
+
+/**
+ * Get all artifacts (from index, without HTML content)
+ */
+export async function getArtifacts(): Promise<Omit<LocalArtifact, "htmlContent">[]> {
+  const index = await getLibraryIndex();
+  return index.artifacts;
+}
+
+/**
+ * Get artifacts filtered by project ID
+ */
+export async function getArtifactsByProject(projectId: string): Promise<Omit<LocalArtifact, "htmlContent">[]> {
+  const index = await getLibraryIndex();
+  return index.artifacts.filter((a) => a.projectId === projectId);
+}
+
+/**
+ * Get a specific artifact by ID (includes HTML content)
+ */
+export async function getArtifact(artifactId: string): Promise<LocalArtifact | null> {
+  if (!isTauriContext()) {
+    // Browser fallback - store full artifacts in localStorage
+    const stored = localStorage.getItem(`artifact-${artifactId}`);
+    if (stored) return JSON.parse(stored);
+    return null;
+  }
+
+  try {
+    const result = await invoke<string>("get_artifact", { artifactId });
+    return JSON.parse(result);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save an artifact
+ */
+export async function saveArtifact(artifact: LocalArtifact): Promise<void> {
+  if (!isTauriContext()) {
+    // Browser fallback
+    // Save full artifact separately
+    localStorage.setItem(`artifact-${artifact.artifactId}`, JSON.stringify(artifact));
+
+    // Update index (without HTML content)
+    const index = await getLibraryIndex();
+    const indexEntry: Omit<LocalArtifact, "htmlContent"> = {
+      artifactId: artifact.artifactId,
+      projectId: artifact.projectId,
+      jobId: artifact.jobId,
+      type: artifact.type,
+      title: artifact.title,
+      grade: artifact.grade,
+      subject: artifact.subject,
+      objectiveTags: artifact.objectiveTags,
+      designPackId: artifact.designPackId,
+      filePath: artifact.filePath,
+      createdAt: artifact.createdAt,
+    };
+
+    // Remove existing entry with same ID
+    index.artifacts = index.artifacts.filter((a) => a.artifactId !== artifact.artifactId);
+    index.artifacts.push(indexEntry as LocalArtifact);
+    index.lastUpdated = new Date().toISOString();
+
+    await saveLibraryIndex(index);
+    return;
+  }
+
+  await invoke("save_artifact", {
+    artifact: JSON.stringify(artifact),
+  });
+}
+
+/**
+ * Delete an artifact
+ */
+export async function deleteArtifact(artifactId: string): Promise<void> {
+  if (!isTauriContext()) {
+    // Browser fallback
+    localStorage.removeItem(`artifact-${artifactId}`);
+
+    // Update index
+    const index = await getLibraryIndex();
+    index.artifacts = index.artifacts.filter((a) => a.artifactId !== artifactId);
+    index.lastUpdated = new Date().toISOString();
+    await saveLibraryIndex(index);
+    return;
+  }
+
+  await invoke("delete_artifact", { artifactId });
+}
+
+/**
+ * Search artifacts with filters
+ */
+export async function searchArtifacts(query: ArtifactSearchQuery): Promise<Omit<LocalArtifact, "htmlContent">[]> {
+  if (!isTauriContext()) {
+    // Browser fallback - filter locally
+    const index = await getLibraryIndex();
+    let results = index.artifacts;
+
+    if (query.projectId) {
+      results = results.filter((a) => a.projectId === query.projectId);
+    }
+    if (query.grade) {
+      results = results.filter((a) => a.grade === query.grade);
+    }
+    if (query.subject) {
+      results = results.filter((a) => a.subject === query.subject);
+    }
+    if (query.type) {
+      results = results.filter((a) => a.type === query.type);
+    }
+    if (query.objectiveTag) {
+      results = results.filter((a) => a.objectiveTags.includes(query.objectiveTag!));
+    }
+    if (query.designPackId) {
+      results = results.filter((a) => a.designPackId === query.designPackId);
+    }
+    if (query.searchText) {
+      const searchLower = query.searchText.toLowerCase();
+      results = results.filter((a) => a.title.toLowerCase().includes(searchLower));
+    }
+
+    return results;
+  }
+
+  const result = await invoke<string>("search_artifacts", {
+    query: JSON.stringify(query),
+  });
+  return JSON.parse(result);
+}
+
+/**
+ * Create multiple artifacts from a generation result
+ */
+export async function saveArtifactsFromGeneration(
+  projectId: string,
+  jobId: string,
+  grade: string,
+  subject: string,
+  title: string,
+  objectiveTags: string[],
+  designPackId: string | undefined,
+  contents: {
+    studentPage?: string;
+    teacherScript?: string;
+    answerKey?: string;
+    lessonPlan?: string;
+  }
+): Promise<LocalArtifact[]> {
+  const now = new Date().toISOString();
+  const artifacts: LocalArtifact[] = [];
+
+  if (contents.studentPage) {
+    const artifact: LocalArtifact = {
+      artifactId: crypto.randomUUID(),
+      projectId,
+      jobId,
+      type: "student_page",
+      title: `${title} - Student Page`,
+      htmlContent: contents.studentPage,
+      grade: grade as LocalArtifact["grade"],
+      subject,
+      objectiveTags,
+      designPackId,
+      createdAt: now,
+    };
+    await saveArtifact(artifact);
+    artifacts.push(artifact);
+  }
+
+  if (contents.teacherScript) {
+    const artifact: LocalArtifact = {
+      artifactId: crypto.randomUUID(),
+      projectId,
+      jobId,
+      type: "teacher_script",
+      title: `${title} - Teacher Script`,
+      htmlContent: contents.teacherScript,
+      grade: grade as LocalArtifact["grade"],
+      subject,
+      objectiveTags,
+      designPackId,
+      createdAt: now,
+    };
+    await saveArtifact(artifact);
+    artifacts.push(artifact);
+  }
+
+  if (contents.answerKey) {
+    const artifact: LocalArtifact = {
+      artifactId: crypto.randomUUID(),
+      projectId,
+      jobId,
+      type: "answer_key",
+      title: `${title} - Answer Key`,
+      htmlContent: contents.answerKey,
+      grade: grade as LocalArtifact["grade"],
+      subject,
+      objectiveTags,
+      designPackId,
+      createdAt: now,
+    };
+    await saveArtifact(artifact);
+    artifacts.push(artifact);
+  }
+
+  if (contents.lessonPlan) {
+    const artifact: LocalArtifact = {
+      artifactId: crypto.randomUUID(),
+      projectId,
+      jobId,
+      type: "lesson_plan",
+      title: `${title} - Lesson Plan`,
+      htmlContent: contents.lessonPlan,
+      grade: grade as LocalArtifact["grade"],
+      subject,
+      objectiveTags,
+      designPackId,
+      createdAt: now,
+    };
+    await saveArtifact(artifact);
+    artifacts.push(artifact);
+  }
+
+  return artifacts;
+}

--- a/src/services/local-project-storage.ts
+++ b/src/services/local-project-storage.ts
@@ -1,0 +1,284 @@
+import { invoke } from "@tauri-apps/api/core";
+import { isTauriContext } from "./tauri-bridge";
+import type {
+  UnifiedProject,
+  ProjectType,
+  CreateUnifiedProjectData,
+  ProjectSummary,
+  gradeToGradeBand,
+} from "@/types";
+
+// ============================================
+// Local Project Functions
+// ============================================
+
+/**
+ * Get all local projects
+ */
+export async function getLocalProjects(): Promise<UnifiedProject[]> {
+  if (!isTauriContext()) {
+    // Browser fallback - use localStorage
+    const stored = localStorage.getItem("local-projects");
+    return stored ? JSON.parse(stored) : [];
+  }
+
+  const result = await invoke<string>("get_local_projects");
+  return JSON.parse(result);
+}
+
+/**
+ * Get a specific project by ID
+ */
+export async function getLocalProject(projectId: string): Promise<UnifiedProject | null> {
+  if (!isTauriContext()) {
+    // Browser fallback
+    const projects = await getLocalProjects();
+    return projects.find((p) => p.projectId === projectId) || null;
+  }
+
+  try {
+    const result = await invoke<string>("get_local_project", { projectId });
+    return JSON.parse(result);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save a local project (create or update)
+ */
+export async function saveLocalProject(project: UnifiedProject): Promise<void> {
+  if (!isTauriContext()) {
+    // Browser fallback
+    const projects = await getLocalProjects();
+    const index = projects.findIndex((p) => p.projectId === project.projectId);
+    if (index >= 0) {
+      projects[index] = project;
+    } else {
+      projects.push(project);
+    }
+    localStorage.setItem("local-projects", JSON.stringify(projects));
+    return;
+  }
+
+  await invoke("save_local_project", {
+    project: JSON.stringify(project),
+  });
+}
+
+/**
+ * Create a new unified project
+ */
+export async function createLocalProject(data: CreateUnifiedProjectData): Promise<UnifiedProject> {
+  const now = new Date().toISOString();
+
+  // Import gradeToGradeBand dynamically to avoid circular deps
+  const { gradeToGradeBand } = await import("@/types");
+
+  const project: UnifiedProject = {
+    projectId: crypto.randomUUID(),
+    type: data.type,
+    name: data.name,
+    description: data.description,
+    grade: data.grade,
+    gradeBand: gradeToGradeBand(data.grade),
+    subjectFocus: data.subjectFocus || [],
+    learnerId: data.learnerId,
+    linkedObjectiveIds: data.linkedObjectiveIds,
+    defaultDesignPackId: data.defaultDesignPackId,
+    artifactIds: [],
+    status: "pending",
+    lastActivityDate: now,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  await saveLocalProject(project);
+  return project;
+}
+
+/**
+ * Update a local project
+ */
+export async function updateLocalProject(
+  projectId: string,
+  updates: Partial<Omit<UnifiedProject, "projectId" | "createdAt">>
+): Promise<UnifiedProject> {
+  const project = await getLocalProject(projectId);
+  if (!project) {
+    throw new Error(`Project not found: ${projectId}`);
+  }
+
+  const updated: UnifiedProject = {
+    ...project,
+    ...updates,
+    updatedAt: new Date().toISOString(),
+  };
+
+  await saveLocalProject(updated);
+  return updated;
+}
+
+/**
+ * Delete a local project
+ */
+export async function deleteLocalProject(projectId: string): Promise<void> {
+  if (!isTauriContext()) {
+    // Browser fallback
+    const projects = await getLocalProjects();
+    const filtered = projects.filter((p) => p.projectId !== projectId);
+    localStorage.setItem("local-projects", JSON.stringify(filtered));
+    return;
+  }
+
+  await invoke("delete_local_project", { projectId });
+}
+
+/**
+ * Get projects by type
+ */
+export async function getProjectsByType(type: ProjectType): Promise<UnifiedProject[]> {
+  if (!isTauriContext()) {
+    // Browser fallback
+    const projects = await getLocalProjects();
+    return projects.filter((p) => p.type === type);
+  }
+
+  const result = await invoke<string>("get_projects_by_type", { projectType: type });
+  return JSON.parse(result);
+}
+
+/**
+ * Get learning path projects
+ */
+export async function getLearningPathProjects(): Promise<UnifiedProject[]> {
+  return getProjectsByType("learning_path");
+}
+
+/**
+ * Get quick create projects
+ */
+export async function getQuickCreateProjects(): Promise<UnifiedProject[]> {
+  return getProjectsByType("quick_create");
+}
+
+/**
+ * Add artifact to project
+ */
+export async function addArtifactToProject(
+  projectId: string,
+  artifactId: string
+): Promise<void> {
+  if (!isTauriContext()) {
+    // Browser fallback
+    const project = await getLocalProject(projectId);
+    if (!project) {
+      throw new Error(`Project not found: ${projectId}`);
+    }
+
+    if (!project.artifactIds.includes(artifactId)) {
+      project.artifactIds.push(artifactId);
+      project.lastActivityDate = new Date().toISOString();
+      project.updatedAt = new Date().toISOString();
+      await saveLocalProject(project);
+    }
+    return;
+  }
+
+  await invoke("add_artifact_to_project", { projectId, artifactId });
+}
+
+/**
+ * Link objective to project
+ */
+export async function linkObjectiveToProject(
+  projectId: string,
+  objectiveId: string
+): Promise<void> {
+  const project = await getLocalProject(projectId);
+  if (!project) {
+    throw new Error(`Project not found: ${projectId}`);
+  }
+
+  if (!project.linkedObjectiveIds) {
+    project.linkedObjectiveIds = [];
+  }
+
+  if (!project.linkedObjectiveIds.includes(objectiveId)) {
+    project.linkedObjectiveIds.push(objectiveId);
+    project.updatedAt = new Date().toISOString();
+    await saveLocalProject(project);
+  }
+}
+
+/**
+ * Unlink objective from project
+ */
+export async function unlinkObjectiveFromProject(
+  projectId: string,
+  objectiveId: string
+): Promise<void> {
+  const project = await getLocalProject(projectId);
+  if (!project) {
+    throw new Error(`Project not found: ${projectId}`);
+  }
+
+  if (project.linkedObjectiveIds) {
+    project.linkedObjectiveIds = project.linkedObjectiveIds.filter((id) => id !== objectiveId);
+    project.updatedAt = new Date().toISOString();
+    await saveLocalProject(project);
+  }
+}
+
+/**
+ * Get project summaries for display in lists
+ */
+export async function getProjectSummaries(): Promise<ProjectSummary[]> {
+  const projects = await getLocalProjects();
+
+  return projects.map((p) => ({
+    projectId: p.projectId,
+    type: p.type,
+    name: p.name,
+    grade: p.grade,
+    subjectFocus: p.subjectFocus,
+    lastActivityDate: p.lastActivityDate,
+    artifactCount: p.artifactIds.length,
+    learnerId: p.learnerId,
+  }));
+}
+
+/**
+ * Get the most recently used project
+ */
+export async function getMostRecentProject(): Promise<UnifiedProject | null> {
+  const projects = await getLocalProjects();
+  if (projects.length === 0) return null;
+
+  // Sort by lastActivityDate descending
+  const sorted = [...projects].sort(
+    (a, b) => new Date(b.lastActivityDate).getTime() - new Date(a.lastActivityDate).getTime()
+  );
+
+  return sorted[0];
+}
+
+/**
+ * Update project status
+ */
+export async function updateProjectStatus(
+  projectId: string,
+  status: UnifiedProject["status"]
+): Promise<void> {
+  await updateLocalProject(projectId, { status });
+}
+
+/**
+ * Set default design pack for project
+ */
+export async function setProjectDesignPack(
+  projectId: string,
+  designPackId: string | undefined
+): Promise<void> {
+  await updateLocalProject(projectId, { defaultDesignPackId: designPackId });
+}

--- a/src/stores/artifactStore.ts
+++ b/src/stores/artifactStore.ts
@@ -1,0 +1,330 @@
+import { create } from "zustand";
+import type {
+  LocalArtifact,
+  ArtifactSearchQuery,
+  ArtifactType,
+  Grade,
+  LibraryFilters,
+  LibraryViewMode,
+  LibrarySortBy,
+} from "@/types";
+import {
+  getArtifacts,
+  getArtifact,
+  saveArtifact,
+  deleteArtifact,
+  searchArtifacts,
+  saveArtifactsFromGeneration,
+} from "@/services/library-storage";
+
+interface ArtifactState {
+  // Artifact list state
+  artifacts: Omit<LocalArtifact, "htmlContent">[];
+  isLoading: boolean;
+  error: string | null;
+
+  // Current artifact state (with full content)
+  currentArtifact: LocalArtifact | null;
+  isLoadingCurrent: boolean;
+
+  // Library UI state
+  viewMode: LibraryViewMode;
+  sortBy: LibrarySortBy;
+  filters: LibraryFilters;
+  searchQuery: string;
+
+  // Computed helpers
+  getArtifactsByProject: (projectId: string) => Omit<LocalArtifact, "htmlContent">[];
+  getArtifactsByType: (type: ArtifactType) => Omit<LocalArtifact, "htmlContent">[];
+  getFilteredArtifacts: () => Omit<LocalArtifact, "htmlContent">[];
+
+  // Actions
+  loadArtifacts: () => Promise<void>;
+  loadArtifact: (artifactId: string) => Promise<LocalArtifact | null>;
+  saveArtifact: (artifact: LocalArtifact) => Promise<void>;
+  deleteArtifact: (artifactId: string) => Promise<void>;
+  searchArtifacts: (query: ArtifactSearchQuery) => Promise<void>;
+
+  // Batch save from generation
+  saveFromGeneration: (params: {
+    projectId: string;
+    jobId: string;
+    grade: string;
+    subject: string;
+    title: string;
+    objectiveTags: string[];
+    designPackId?: string;
+    contents: {
+      studentPage?: string;
+      teacherScript?: string;
+      answerKey?: string;
+      lessonPlan?: string;
+    };
+  }) => Promise<LocalArtifact[]>;
+
+  // UI state actions
+  setViewMode: (mode: LibraryViewMode) => void;
+  setSortBy: (sort: LibrarySortBy) => void;
+  setFilters: (filters: Partial<LibraryFilters>) => void;
+  clearFilters: () => void;
+  setSearchQuery: (query: string) => void;
+  setCurrentArtifact: (artifact: LocalArtifact | null) => void;
+
+  // Utility actions
+  clearError: () => void;
+  reset: () => void;
+}
+
+const DEFAULT_FILTERS: LibraryFilters = {
+  projects: [],
+  grades: [],
+  subjects: [],
+  types: [],
+  objectiveTags: [],
+};
+
+export const useArtifactStore = create<ArtifactState>()((set, get) => ({
+  // Initial state
+  artifacts: [],
+  isLoading: false,
+  error: null,
+  currentArtifact: null,
+  isLoadingCurrent: false,
+  viewMode: "grid",
+  sortBy: "date_desc",
+  filters: DEFAULT_FILTERS,
+  searchQuery: "",
+
+  // ============================================
+  // Computed Helpers
+  // ============================================
+
+  getArtifactsByProject: (projectId: string) => {
+    const { artifacts } = get();
+    return artifacts.filter((a) => a.projectId === projectId);
+  },
+
+  getArtifactsByType: (type: ArtifactType) => {
+    const { artifacts } = get();
+    return artifacts.filter((a) => a.type === type);
+  },
+
+  getFilteredArtifacts: () => {
+    const { artifacts, filters, searchQuery, sortBy } = get();
+    let filtered = [...artifacts];
+
+    // Apply filters
+    if (filters.projects.length > 0) {
+      filtered = filtered.filter((a) => filters.projects.includes(a.projectId));
+    }
+    if (filters.grades.length > 0) {
+      filtered = filtered.filter((a) => filters.grades.includes(a.grade));
+    }
+    if (filters.subjects.length > 0) {
+      filtered = filtered.filter((a) => filters.subjects.includes(a.subject));
+    }
+    if (filters.types.length > 0) {
+      filtered = filtered.filter((a) => filters.types.includes(a.type));
+    }
+    if (filters.objectiveTags.length > 0) {
+      filtered = filtered.filter((a) =>
+        a.objectiveTags.some((t) => filters.objectiveTags.includes(t))
+      );
+    }
+    if (filters.dateRange) {
+      const fromDate = new Date(filters.dateRange.from);
+      const toDate = new Date(filters.dateRange.to);
+      filtered = filtered.filter((a) => {
+        const createdAt = new Date(a.createdAt);
+        return createdAt >= fromDate && createdAt <= toDate;
+      });
+    }
+
+    // Apply search
+    if (searchQuery.trim()) {
+      const query = searchQuery.toLowerCase();
+      filtered = filtered.filter((a) =>
+        a.title.toLowerCase().includes(query)
+      );
+    }
+
+    // Apply sort
+    switch (sortBy) {
+      case "date_desc":
+        filtered.sort((a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        );
+        break;
+      case "date_asc":
+        filtered.sort((a, b) =>
+          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+        );
+        break;
+      case "title_asc":
+        filtered.sort((a, b) => a.title.localeCompare(b.title));
+        break;
+      case "title_desc":
+        filtered.sort((a, b) => b.title.localeCompare(a.title));
+        break;
+      case "grade":
+        const gradeOrder: Record<Grade, number> = {
+          K: 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6,
+        };
+        filtered.sort((a, b) => gradeOrder[a.grade] - gradeOrder[b.grade]);
+        break;
+    }
+
+    return filtered;
+  },
+
+  // ============================================
+  // Data Actions
+  // ============================================
+
+  loadArtifacts: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const artifacts = await getArtifacts();
+      set({ artifacts, isLoading: false });
+    } catch (error) {
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : "Failed to load artifacts",
+      });
+    }
+  },
+
+  loadArtifact: async (artifactId: string) => {
+    set({ isLoadingCurrent: true });
+    try {
+      const artifact = await getArtifact(artifactId);
+      set({ currentArtifact: artifact, isLoadingCurrent: false });
+      return artifact;
+    } catch (error) {
+      set({ isLoadingCurrent: false });
+      console.error("Failed to load artifact:", error);
+      return null;
+    }
+  },
+
+  saveArtifact: async (artifact: LocalArtifact) => {
+    set({ isLoading: true, error: null });
+    try {
+      await saveArtifact(artifact);
+      // Reload artifacts to get updated index
+      await get().loadArtifacts();
+    } catch (error) {
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : "Failed to save artifact",
+      });
+      throw error;
+    }
+  },
+
+  deleteArtifact: async (artifactId: string) => {
+    set({ isLoading: true, error: null });
+    try {
+      await deleteArtifact(artifactId);
+      set((state) => ({
+        artifacts: state.artifacts.filter((a) => a.artifactId !== artifactId),
+        currentArtifact:
+          state.currentArtifact?.artifactId === artifactId
+            ? null
+            : state.currentArtifact,
+        isLoading: false,
+      }));
+    } catch (error) {
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : "Failed to delete artifact",
+      });
+      throw error;
+    }
+  },
+
+  searchArtifacts: async (query: ArtifactSearchQuery) => {
+    set({ isLoading: true, error: null });
+    try {
+      const artifacts = await searchArtifacts(query);
+      set({ artifacts, isLoading: false });
+    } catch (error) {
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : "Failed to search artifacts",
+      });
+    }
+  },
+
+  saveFromGeneration: async (params) => {
+    try {
+      const artifacts = await saveArtifactsFromGeneration(
+        params.projectId,
+        params.jobId,
+        params.grade,
+        params.subject,
+        params.title,
+        params.objectiveTags,
+        params.designPackId,
+        params.contents
+      );
+
+      // Reload artifacts to get updated index
+      await get().loadArtifacts();
+
+      return artifacts;
+    } catch (error) {
+      console.error("Failed to save artifacts from generation:", error);
+      throw error;
+    }
+  },
+
+  // ============================================
+  // UI State Actions
+  // ============================================
+
+  setViewMode: (mode: LibraryViewMode) => set({ viewMode: mode }),
+
+  setSortBy: (sort: LibrarySortBy) => set({ sortBy: sort }),
+
+  setFilters: (filters: Partial<LibraryFilters>) =>
+    set((state) => ({
+      filters: { ...state.filters, ...filters },
+    })),
+
+  clearFilters: () => set({ filters: DEFAULT_FILTERS, searchQuery: "" }),
+
+  setSearchQuery: (query: string) => set({ searchQuery: query }),
+
+  setCurrentArtifact: (artifact: LocalArtifact | null) =>
+    set({ currentArtifact: artifact }),
+
+  // ============================================
+  // Utility Actions
+  // ============================================
+
+  clearError: () => set({ error: null }),
+
+  reset: () =>
+    set({
+      artifacts: [],
+      isLoading: false,
+      error: null,
+      currentArtifact: null,
+      isLoadingCurrent: false,
+      viewMode: "grid",
+      sortBy: "date_desc",
+      filters: DEFAULT_FILTERS,
+      searchQuery: "",
+    }),
+}));
+
+// Export convenience selector hooks
+export const useFilteredArtifacts = () =>
+  useArtifactStore((state) => state.getFilteredArtifacts());
+
+export const useArtifactsByProject = (projectId: string) =>
+  useArtifactStore((state) => state.getArtifactsByProject(projectId));
+
+export const useCurrentArtifact = () =>
+  useArtifactStore((state) => state.currentArtifact);

--- a/src/stores/designPackStore.ts
+++ b/src/stores/designPackStore.ts
@@ -1,0 +1,307 @@
+import { create } from "zustand";
+import type {
+  DesignPack,
+  DesignPackItem,
+  CreateDesignPackData,
+} from "@/types";
+import {
+  getDesignPacks,
+  getDesignPack,
+  createDesignPack,
+  updateDesignPack,
+  deleteDesignPack,
+  addItemToDesignPack,
+  removeItemFromDesignPack,
+  reorderDesignPackItems,
+  createDesignPackFromLegacyItems,
+} from "@/services/design-pack-storage";
+
+interface DesignPackState {
+  // Design pack state
+  packs: DesignPack[];
+  isLoading: boolean;
+  error: string | null;
+
+  // Current pack for editing
+  currentPackId: string | null;
+  currentPack: DesignPack | null;
+
+  // Selected pack for generation (wizard)
+  selectedPackId: string | null;
+
+  // Computed helpers
+  getPackById: (packId: string) => DesignPack | null;
+  getSelectedPack: () => DesignPack | null;
+
+  // Pack CRUD actions
+  loadPacks: () => Promise<void>;
+  loadPack: (packId: string) => Promise<DesignPack | null>;
+  createPack: (data: CreateDesignPackData) => Promise<DesignPack>;
+  updatePack: (
+    packId: string,
+    updates: Partial<Omit<DesignPack, "packId" | "createdAt">>
+  ) => Promise<void>;
+  deletePack: (packId: string) => Promise<void>;
+
+  // Item management actions
+  addItem: (packId: string, item: Omit<DesignPackItem, "itemId">) => Promise<DesignPackItem>;
+  removeItem: (packId: string, itemId: string) => Promise<void>;
+  reorderItems: (packId: string, itemIds: string[]) => Promise<void>;
+
+  // Migration actions
+  createFromLegacyItems: (
+    name: string,
+    legacyItems: Array<{
+      id: string;
+      type: "url" | "pdf" | "image" | "text";
+      title: string;
+      sourceUrl?: string;
+      content?: string;
+      storagePath?: string;
+    }>
+  ) => Promise<DesignPack>;
+
+  // Selection actions
+  setCurrentPack: (packId: string | null) => void;
+  selectPack: (packId: string | null) => void;
+
+  // Utility actions
+  clearError: () => void;
+  reset: () => void;
+}
+
+export const useDesignPackStore = create<DesignPackState>()((set, get) => ({
+  // Initial state
+  packs: [],
+  isLoading: false,
+  error: null,
+  currentPackId: null,
+  currentPack: null,
+  selectedPackId: null,
+
+  // ============================================
+  // Computed Helpers
+  // ============================================
+
+  getPackById: (packId: string) => {
+    const { packs } = get();
+    return packs.find((p) => p.packId === packId) || null;
+  },
+
+  getSelectedPack: () => {
+    const { packs, selectedPackId } = get();
+    if (!selectedPackId) return null;
+    return packs.find((p) => p.packId === selectedPackId) || null;
+  },
+
+  // ============================================
+  // Pack CRUD Actions
+  // ============================================
+
+  loadPacks: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const packs = await getDesignPacks();
+      set({ packs, isLoading: false });
+    } catch (error) {
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : "Failed to load design packs",
+      });
+    }
+  },
+
+  loadPack: async (packId: string) => {
+    try {
+      const pack = await getDesignPack(packId);
+      if (pack) {
+        set({ currentPack: pack, currentPackId: packId });
+      }
+      return pack;
+    } catch (error) {
+      console.error("Failed to load design pack:", error);
+      return null;
+    }
+  },
+
+  createPack: async (data: CreateDesignPackData) => {
+    set({ isLoading: true, error: null });
+    try {
+      const pack = await createDesignPack(data);
+      set((state) => ({
+        packs: [...state.packs, pack],
+        isLoading: false,
+      }));
+      return pack;
+    } catch (error) {
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : "Failed to create design pack",
+      });
+      throw error;
+    }
+  },
+
+  updatePack: async (packId, updates) => {
+    set({ isLoading: true, error: null });
+    try {
+      const updated = await updateDesignPack(packId, updates);
+      set((state) => ({
+        packs: state.packs.map((p) => (p.packId === packId ? updated : p)),
+        currentPack: state.currentPackId === packId ? updated : state.currentPack,
+        isLoading: false,
+      }));
+    } catch (error) {
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : "Failed to update design pack",
+      });
+      throw error;
+    }
+  },
+
+  deletePack: async (packId: string) => {
+    set({ isLoading: true, error: null });
+    try {
+      await deleteDesignPack(packId);
+      set((state) => ({
+        packs: state.packs.filter((p) => p.packId !== packId),
+        currentPackId: state.currentPackId === packId ? null : state.currentPackId,
+        currentPack: state.currentPackId === packId ? null : state.currentPack,
+        selectedPackId: state.selectedPackId === packId ? null : state.selectedPackId,
+        isLoading: false,
+      }));
+    } catch (error) {
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : "Failed to delete design pack",
+      });
+      throw error;
+    }
+  },
+
+  // ============================================
+  // Item Management Actions
+  // ============================================
+
+  addItem: async (packId: string, item: Omit<DesignPackItem, "itemId">) => {
+    try {
+      const newItem = await addItemToDesignPack(packId, item);
+
+      // Reload pack to get updated state
+      const updatedPack = await getDesignPack(packId);
+      if (updatedPack) {
+        set((state) => ({
+          packs: state.packs.map((p) => (p.packId === packId ? updatedPack : p)),
+          currentPack: state.currentPackId === packId ? updatedPack : state.currentPack,
+        }));
+      }
+
+      return newItem;
+    } catch (error) {
+      console.error("Failed to add item to design pack:", error);
+      throw error;
+    }
+  },
+
+  removeItem: async (packId: string, itemId: string) => {
+    try {
+      await removeItemFromDesignPack(packId, itemId);
+
+      // Reload pack to get updated state
+      const updatedPack = await getDesignPack(packId);
+      if (updatedPack) {
+        set((state) => ({
+          packs: state.packs.map((p) => (p.packId === packId ? updatedPack : p)),
+          currentPack: state.currentPackId === packId ? updatedPack : state.currentPack,
+        }));
+      }
+    } catch (error) {
+      console.error("Failed to remove item from design pack:", error);
+      throw error;
+    }
+  },
+
+  reorderItems: async (packId: string, itemIds: string[]) => {
+    try {
+      await reorderDesignPackItems(packId, itemIds);
+
+      // Reload pack to get updated state
+      const updatedPack = await getDesignPack(packId);
+      if (updatedPack) {
+        set((state) => ({
+          packs: state.packs.map((p) => (p.packId === packId ? updatedPack : p)),
+          currentPack: state.currentPackId === packId ? updatedPack : state.currentPack,
+        }));
+      }
+    } catch (error) {
+      console.error("Failed to reorder design pack items:", error);
+      throw error;
+    }
+  },
+
+  // ============================================
+  // Migration Actions
+  // ============================================
+
+  createFromLegacyItems: async (name, legacyItems) => {
+    set({ isLoading: true, error: null });
+    try {
+      const pack = await createDesignPackFromLegacyItems(name, legacyItems);
+      set((state) => ({
+        packs: [...state.packs, pack],
+        isLoading: false,
+      }));
+      return pack;
+    } catch (error) {
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : "Failed to create design pack from legacy items",
+      });
+      throw error;
+    }
+  },
+
+  // ============================================
+  // Selection Actions
+  // ============================================
+
+  setCurrentPack: (packId: string | null) => {
+    if (packId) {
+      const pack = get().getPackById(packId);
+      set({ currentPackId: packId, currentPack: pack });
+    } else {
+      set({ currentPackId: null, currentPack: null });
+    }
+  },
+
+  selectPack: (packId: string | null) => {
+    set({ selectedPackId: packId });
+  },
+
+  // ============================================
+  // Utility Actions
+  // ============================================
+
+  clearError: () => set({ error: null }),
+
+  reset: () =>
+    set({
+      packs: [],
+      isLoading: false,
+      error: null,
+      currentPackId: null,
+      currentPack: null,
+      selectedPackId: null,
+    }),
+}));
+
+// Export convenience selector hooks
+export const useDesignPacks = () =>
+  useDesignPackStore((state) => state.packs);
+
+export const useSelectedDesignPack = () =>
+  useDesignPackStore((state) => state.getSelectedPack());
+
+export const useCurrentDesignPack = () =>
+  useDesignPackStore((state) => state.currentPack);

--- a/src/stores/unifiedProjectStore.ts
+++ b/src/stores/unifiedProjectStore.ts
@@ -1,0 +1,466 @@
+import { create } from "zustand";
+import type {
+  UnifiedProject,
+  ProjectType,
+  CreateUnifiedProjectData,
+  ProjectSummary,
+  Grade,
+} from "@/types";
+import {
+  getLocalProjects,
+  getLocalProject,
+  createLocalProject,
+  updateLocalProject,
+  deleteLocalProject,
+  getProjectsByType,
+  addArtifactToProject,
+  linkObjectiveToProject,
+  unlinkObjectiveFromProject,
+  getProjectSummaries,
+  getMostRecentProject,
+  setProjectDesignPack,
+} from "@/services/local-project-storage";
+
+// Key for storing current project ID in localStorage
+const CURRENT_PROJECT_KEY = "current-project-id";
+
+interface UnifiedProjectState {
+  // Project list state
+  projects: UnifiedProject[];
+  isLoading: boolean;
+  error: string | null;
+
+  // Current project state
+  currentProjectId: string | null;
+  currentProject: UnifiedProject | null;
+
+  // Project summaries for display
+  summaries: ProjectSummary[];
+
+  // Computed helpers
+  getProjectById: (projectId: string) => UnifiedProject | null;
+  getLearningPathProjects: () => UnifiedProject[];
+  getQuickCreateProjects: () => UnifiedProject[];
+  getProjectsByLearner: (learnerId: string) => UnifiedProject[];
+  getCurrentProject: () => UnifiedProject | null;
+
+  // Project CRUD actions
+  loadProjects: () => Promise<void>;
+  loadProject: (projectId: string) => Promise<UnifiedProject | null>;
+  createProject: (data: CreateUnifiedProjectData) => Promise<UnifiedProject>;
+  updateProject: (
+    projectId: string,
+    updates: Partial<Omit<UnifiedProject, "projectId" | "createdAt">>
+  ) => Promise<void>;
+  deleteProject: (projectId: string) => Promise<void>;
+
+  // Project type filters
+  loadProjectsByType: (type: ProjectType) => Promise<void>;
+
+  // Current project management
+  setCurrentProject: (projectId: string | null) => void;
+  loadCurrentProject: () => Promise<void>;
+
+  // Artifact management
+  addArtifact: (projectId: string, artifactId: string) => Promise<void>;
+
+  // Objective management
+  linkObjective: (projectId: string, objectiveId: string) => Promise<void>;
+  unlinkObjective: (projectId: string, objectiveId: string) => Promise<void>;
+
+  // Design pack management
+  setDesignPack: (projectId: string, designPackId: string | undefined) => Promise<void>;
+
+  // Quick actions
+  createLearningPathProject: (
+    learnerId: string,
+    objectiveId: string,
+    grade: Grade,
+    subject: string
+  ) => Promise<UnifiedProject>;
+  createQuickProject: (
+    name: string,
+    grade: Grade,
+    subjects: string[]
+  ) => Promise<UnifiedProject>;
+
+  // Utility actions
+  clearError: () => void;
+  reset: () => void;
+}
+
+export const useUnifiedProjectStore = create<UnifiedProjectState>()((set, get) => ({
+  // Initial state
+  projects: [],
+  isLoading: false,
+  error: null,
+  currentProjectId: localStorage.getItem(CURRENT_PROJECT_KEY),
+  currentProject: null,
+  summaries: [],
+
+  // ============================================
+  // Computed Helpers
+  // ============================================
+
+  getProjectById: (projectId: string) => {
+    const { projects } = get();
+    return projects.find((p) => p.projectId === projectId) || null;
+  },
+
+  getLearningPathProjects: () => {
+    const { projects } = get();
+    return projects.filter((p) => p.type === "learning_path");
+  },
+
+  getQuickCreateProjects: () => {
+    const { projects } = get();
+    return projects.filter((p) => p.type === "quick_create");
+  },
+
+  getProjectsByLearner: (learnerId: string) => {
+    const { projects } = get();
+    return projects.filter((p) => p.learnerId === learnerId);
+  },
+
+  getCurrentProject: () => {
+    const { projects, currentProjectId } = get();
+    if (!currentProjectId) return null;
+    return projects.find((p) => p.projectId === currentProjectId) || null;
+  },
+
+  // ============================================
+  // Project CRUD Actions
+  // ============================================
+
+  loadProjects: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const projects = await getLocalProjects();
+      const summaries = await getProjectSummaries();
+      set({ projects, summaries, isLoading: false });
+
+      // Load current project if set
+      const { currentProjectId } = get();
+      if (currentProjectId) {
+        const exists = projects.some((p) => p.projectId === currentProjectId);
+        if (exists) {
+          const currentProject = projects.find((p) => p.projectId === currentProjectId) || null;
+          set({ currentProject });
+        } else {
+          // Current project no longer exists, clear it
+          set({ currentProjectId: null, currentProject: null });
+          localStorage.removeItem(CURRENT_PROJECT_KEY);
+        }
+      }
+    } catch (error) {
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : "Failed to load projects",
+      });
+    }
+  },
+
+  loadProject: async (projectId: string) => {
+    try {
+      const project = await getLocalProject(projectId);
+      return project;
+    } catch (error) {
+      console.error("Failed to load project:", error);
+      return null;
+    }
+  },
+
+  createProject: async (data: CreateUnifiedProjectData) => {
+    set({ isLoading: true, error: null });
+    try {
+      const project = await createLocalProject(data);
+      set((state) => ({
+        projects: [...state.projects, project],
+        isLoading: false,
+      }));
+
+      // Reload summaries
+      const summaries = await getProjectSummaries();
+      set({ summaries });
+
+      return project;
+    } catch (error) {
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : "Failed to create project",
+      });
+      throw error;
+    }
+  },
+
+  updateProject: async (projectId, updates) => {
+    set({ isLoading: true, error: null });
+    try {
+      const updated = await updateLocalProject(projectId, updates);
+      set((state) => ({
+        projects: state.projects.map((p) => (p.projectId === projectId ? updated : p)),
+        currentProject: state.currentProjectId === projectId ? updated : state.currentProject,
+        isLoading: false,
+      }));
+
+      // Reload summaries
+      const summaries = await getProjectSummaries();
+      set({ summaries });
+    } catch (error) {
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : "Failed to update project",
+      });
+      throw error;
+    }
+  },
+
+  deleteProject: async (projectId: string) => {
+    set({ isLoading: true, error: null });
+    try {
+      await deleteLocalProject(projectId);
+      set((state) => ({
+        projects: state.projects.filter((p) => p.projectId !== projectId),
+        currentProjectId:
+          state.currentProjectId === projectId ? null : state.currentProjectId,
+        currentProject:
+          state.currentProjectId === projectId ? null : state.currentProject,
+        isLoading: false,
+      }));
+
+      // Update localStorage
+      const { currentProjectId } = get();
+      if (!currentProjectId) {
+        localStorage.removeItem(CURRENT_PROJECT_KEY);
+      }
+
+      // Reload summaries
+      const summaries = await getProjectSummaries();
+      set({ summaries });
+    } catch (error) {
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : "Failed to delete project",
+      });
+      throw error;
+    }
+  },
+
+  // ============================================
+  // Project Type Filters
+  // ============================================
+
+  loadProjectsByType: async (type: ProjectType) => {
+    set({ isLoading: true, error: null });
+    try {
+      const projects = await getProjectsByType(type);
+      set({ projects, isLoading: false });
+    } catch (error) {
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : "Failed to load projects",
+      });
+    }
+  },
+
+  // ============================================
+  // Current Project Management
+  // ============================================
+
+  setCurrentProject: (projectId: string | null) => {
+    if (projectId) {
+      localStorage.setItem(CURRENT_PROJECT_KEY, projectId);
+      const project = get().getProjectById(projectId);
+      set({ currentProjectId: projectId, currentProject: project });
+    } else {
+      localStorage.removeItem(CURRENT_PROJECT_KEY);
+      set({ currentProjectId: null, currentProject: null });
+    }
+  },
+
+  loadCurrentProject: async () => {
+    const { currentProjectId } = get();
+    if (!currentProjectId) return;
+
+    const project = await getLocalProject(currentProjectId);
+    if (project) {
+      set({ currentProject: project });
+    } else {
+      // Project no longer exists, clear it
+      set({ currentProjectId: null, currentProject: null });
+      localStorage.removeItem(CURRENT_PROJECT_KEY);
+    }
+  },
+
+  // ============================================
+  // Artifact Management
+  // ============================================
+
+  addArtifact: async (projectId: string, artifactId: string) => {
+    try {
+      await addArtifactToProject(projectId, artifactId);
+
+      // Update local state
+      set((state) => ({
+        projects: state.projects.map((p) => {
+          if (p.projectId === projectId) {
+            return {
+              ...p,
+              artifactIds: p.artifactIds.includes(artifactId)
+                ? p.artifactIds
+                : [...p.artifactIds, artifactId],
+              lastActivityDate: new Date().toISOString(),
+            };
+          }
+          return p;
+        }),
+        currentProject:
+          state.currentProjectId === projectId && state.currentProject
+            ? {
+                ...state.currentProject,
+                artifactIds: state.currentProject.artifactIds.includes(artifactId)
+                  ? state.currentProject.artifactIds
+                  : [...state.currentProject.artifactIds, artifactId],
+                lastActivityDate: new Date().toISOString(),
+              }
+            : state.currentProject,
+      }));
+    } catch (error) {
+      console.error("Failed to add artifact to project:", error);
+      throw error;
+    }
+  },
+
+  // ============================================
+  // Objective Management
+  // ============================================
+
+  linkObjective: async (projectId: string, objectiveId: string) => {
+    try {
+      await linkObjectiveToProject(projectId, objectiveId);
+
+      // Update local state
+      set((state) => ({
+        projects: state.projects.map((p) => {
+          if (p.projectId === projectId) {
+            const linkedObjectiveIds = p.linkedObjectiveIds || [];
+            return {
+              ...p,
+              linkedObjectiveIds: linkedObjectiveIds.includes(objectiveId)
+                ? linkedObjectiveIds
+                : [...linkedObjectiveIds, objectiveId],
+            };
+          }
+          return p;
+        }),
+      }));
+    } catch (error) {
+      console.error("Failed to link objective to project:", error);
+      throw error;
+    }
+  },
+
+  unlinkObjective: async (projectId: string, objectiveId: string) => {
+    try {
+      await unlinkObjectiveFromProject(projectId, objectiveId);
+
+      // Update local state
+      set((state) => ({
+        projects: state.projects.map((p) => {
+          if (p.projectId === projectId && p.linkedObjectiveIds) {
+            return {
+              ...p,
+              linkedObjectiveIds: p.linkedObjectiveIds.filter((id) => id !== objectiveId),
+            };
+          }
+          return p;
+        }),
+      }));
+    } catch (error) {
+      console.error("Failed to unlink objective from project:", error);
+      throw error;
+    }
+  },
+
+  // ============================================
+  // Design Pack Management
+  // ============================================
+
+  setDesignPack: async (projectId: string, designPackId: string | undefined) => {
+    try {
+      await setProjectDesignPack(projectId, designPackId);
+
+      // Update local state
+      set((state) => ({
+        projects: state.projects.map((p) => {
+          if (p.projectId === projectId) {
+            return { ...p, defaultDesignPackId: designPackId };
+          }
+          return p;
+        }),
+        currentProject:
+          state.currentProjectId === projectId && state.currentProject
+            ? { ...state.currentProject, defaultDesignPackId: designPackId }
+            : state.currentProject,
+      }));
+    } catch (error) {
+      console.error("Failed to set design pack for project:", error);
+      throw error;
+    }
+  },
+
+  // ============================================
+  // Quick Actions
+  // ============================================
+
+  createLearningPathProject: async (learnerId, objectiveId, grade, subject) => {
+    return get().createProject({
+      type: "learning_path",
+      name: `${subject} Learning Path`,
+      grade,
+      subjectFocus: [subject],
+      learnerId,
+      linkedObjectiveIds: [objectiveId],
+    });
+  },
+
+  createQuickProject: async (name, grade, subjects) => {
+    return get().createProject({
+      type: "quick_create",
+      name,
+      grade,
+      subjectFocus: subjects,
+    });
+  },
+
+  // ============================================
+  // Utility Actions
+  // ============================================
+
+  clearError: () => set({ error: null }),
+
+  reset: () => {
+    localStorage.removeItem(CURRENT_PROJECT_KEY);
+    set({
+      projects: [],
+      isLoading: false,
+      error: null,
+      currentProjectId: null,
+      currentProject: null,
+      summaries: [],
+    });
+  },
+}));
+
+// Export convenience selector hooks
+export const useCurrentProject = () =>
+  useUnifiedProjectStore((state) => state.getCurrentProject());
+
+export const useLearningPathProjects = () =>
+  useUnifiedProjectStore((state) => state.getLearningPathProjects());
+
+export const useQuickCreateProjects = () =>
+  useUnifiedProjectStore((state) => state.getQuickCreateProjects());
+
+export const useProjectSummaries = () =>
+  useUnifiedProjectStore((state) => state.summaries);

--- a/src/types/artifacts.ts
+++ b/src/types/artifacts.ts
@@ -1,0 +1,403 @@
+import type { Grade, ProjectStatus } from "./database";
+import type { MasteryState } from "./learner";
+
+// ============================================
+// Project Unification Types (Issue #20)
+// ============================================
+
+/**
+ * Project type - distinguishes learning path from quick create workflows
+ */
+export type ProjectType = "learning_path" | "quick_create";
+
+/**
+ * Grade band for projects (MVP focuses on K-3)
+ */
+export type GradeBand = "K" | "1" | "2" | "3" | "4-6";
+
+/**
+ * Artifact types representing different output documents
+ */
+export type ArtifactType =
+  | "student_page"      // Main student worksheet/activity
+  | "teacher_script"    // Teacher instructions/guide
+  | "answer_key"        // Answer key for assessment
+  | "lesson_plan"       // Full lesson plan
+  | "print_pack";       // Combined print-ready bundle
+
+// ============================================
+// Objective Tagging Types
+// ============================================
+
+/**
+ * Standard identifier for a learning objective
+ * Format: GRADE.SUBJECT.DOMAIN.SPECIFIC
+ * Examples: K.MATH.COUNT.1_20, 2.READING.COMPREH.MAIN_IDEA
+ */
+export interface ObjectiveTag {
+  id: string;           // Full objective ID (e.g., "K.MATH.COUNT.1_20")
+  standard: string;     // Standard/domain (e.g., "K.MATH.COUNT")
+  description: string;  // Human-readable description
+  grade: Grade;
+  subject: string;
+}
+
+/**
+ * Helper to parse an objective ID into components
+ */
+export function parseObjectiveId(id: string): { grade: string; subject: string; domain: string; specific: string } | null {
+  const parts = id.split(".");
+  if (parts.length < 3) return null;
+  return {
+    grade: parts[0],
+    subject: parts[1],
+    domain: parts[2],
+    specific: parts.slice(3).join("."),
+  };
+}
+
+// ============================================
+// Design Pack Types (formerly Design Inspiration)
+// ============================================
+
+/**
+ * Individual item within a design pack
+ */
+export interface DesignPackItem {
+  itemId: string;
+  type: "url" | "pdf" | "image" | "text";
+  title: string;
+  sourceUrl?: string;     // For URLs
+  content?: string;       // For PDFs/images (base64) or text
+  storagePath?: string;   // Media type for vision API
+}
+
+/**
+ * Parsed design summary from inspiration items
+ */
+export interface ParsedDesignSummary {
+  palette?: string[];     // Color codes extracted
+  tone?: string;          // Friendly, formal, playful, etc.
+  typography?: string;    // Font style hints
+  styleHints?: string[];  // Additional style notes
+}
+
+/**
+ * Design Pack - a named bundle of design inspiration items
+ */
+export interface DesignPack {
+  packId: string;
+  name: string;
+  description?: string;
+  items: DesignPackItem[];
+  parsedSummary?: ParsedDesignSummary;
+  createdAt: string;  // ISO string
+  updatedAt: string;
+}
+
+/**
+ * Data for creating a new design pack
+ */
+export interface CreateDesignPackData {
+  name: string;
+  description?: string;
+  items?: DesignPackItem[];
+}
+
+// ============================================
+// Local Artifact Types (Library Items)
+// ============================================
+
+/**
+ * A stored output artifact from generation
+ */
+export interface LocalArtifact {
+  artifactId: string;
+  projectId: string;
+  jobId: string;            // Generation job ID (version ID)
+  type: ArtifactType;
+  title: string;
+  htmlContent: string;
+  grade: Grade;
+  subject: string;
+  objectiveTags: string[];  // Array of objective IDs
+  designPackId?: string;    // If generated with a design pack
+  filePath?: string;        // Local file path if saved
+  createdAt: string;        // ISO string
+}
+
+/**
+ * Search/filter query for artifacts
+ */
+export interface ArtifactSearchQuery {
+  projectId?: string;
+  grade?: Grade;
+  subject?: string;
+  type?: ArtifactType;
+  objectiveTag?: string;    // Filter by specific objective
+  designPackId?: string;
+  searchText?: string;      // Full-text search in title
+  dateFrom?: string;        // ISO string
+  dateTo?: string;
+}
+
+/**
+ * Artifact with related project info (for library display)
+ */
+export interface ArtifactWithProject extends LocalArtifact {
+  projectTitle: string;
+  projectType: ProjectType;
+}
+
+// ============================================
+// Unified Project Types
+// ============================================
+
+/**
+ * Unified project model supporting both learning path and quick create
+ */
+export interface UnifiedProject {
+  projectId: string;
+  type: ProjectType;
+  name: string;
+  description?: string;
+
+  // Content focus
+  grade: Grade;
+  gradeBand: GradeBand;
+  subjectFocus: string[];   // Primary subjects
+
+  // Learning path specific (optional)
+  learnerId?: string;       // Associated learner profile
+  linkedObjectiveIds?: string[];  // Curriculum objectives being worked on
+
+  // Design settings
+  defaultDesignPackId?: string;
+
+  // Artifact tracking
+  artifactIds: string[];    // Generated artifacts belonging to this project
+
+  // Status
+  status: ProjectStatus;
+  lastActivityDate: string; // ISO string
+
+  // Metadata
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Data for creating a new unified project
+ */
+export interface CreateUnifiedProjectData {
+  type: ProjectType;
+  name: string;
+  description?: string;
+  grade: Grade;
+  subjectFocus?: string[];
+  learnerId?: string;
+  linkedObjectiveIds?: string[];
+  defaultDesignPackId?: string;
+}
+
+/**
+ * Summary data for project cards
+ */
+export interface ProjectSummary {
+  projectId: string;
+  type: ProjectType;
+  name: string;
+  grade: Grade;
+  subjectFocus: string[];
+  lastActivityDate: string;
+  artifactCount: number;
+  // Learning path specific
+  learnerId?: string;
+  learnerName?: string;
+  masteryProgress?: {
+    total: number;
+    mastered: number;
+    inProgress: number;
+  };
+}
+
+// ============================================
+// Mastery Integration Types
+// ============================================
+
+/**
+ * Extended mastery record linking artifacts as evidence
+ */
+export interface MasteryRecordWithEvidence {
+  projectId: string;
+  learnerId: string;
+  objectiveId: string;
+  status: MasteryState;
+  lastUpdatedAt: string;
+  evidenceArtifactIds: string[];  // Artifacts demonstrating mastery
+}
+
+/**
+ * Today's plan item for Learning Path projects
+ */
+export interface TodaysPlanItem {
+  objectiveId: string;
+  objectiveText: string;
+  subject: string;
+  estimatedMinutes: number;
+  status: "pending" | "in_progress" | "completed";
+  linkedArtifactIds: string[];
+}
+
+/**
+ * Today's plan for a learning path project
+ */
+export interface TodaysPlan {
+  projectId: string;
+  date: string;  // ISO date string (YYYY-MM-DD)
+  items: TodaysPlanItem[];
+  totalMinutes: number;
+}
+
+// ============================================
+// Library Index Types
+// ============================================
+
+/**
+ * Library index stored locally (append-only with periodic compaction)
+ */
+export interface LibraryIndex {
+  version: number;
+  lastUpdated: string;
+  artifacts: LocalArtifact[];
+}
+
+/**
+ * Library filter state for UI
+ */
+export interface LibraryFilters {
+  projects: string[];       // Project IDs
+  grades: Grade[];
+  subjects: string[];
+  types: ArtifactType[];
+  objectiveTags: string[];
+  dateRange?: {
+    from: string;
+    to: string;
+  };
+}
+
+/**
+ * Library view mode
+ */
+export type LibraryViewMode = "grid" | "list";
+
+/**
+ * Library sort options
+ */
+export type LibrarySortBy = "date_desc" | "date_asc" | "title_asc" | "title_desc" | "grade";
+
+// ============================================
+// Preview Tab Types
+// ============================================
+
+/**
+ * Standard preview tabs (Issue #20 requirement)
+ */
+export type PreviewTabId =
+  | "student_page"
+  | "teacher_script"
+  | "answer_key"
+  | "lesson_plan"
+  | "print_pack";
+
+/**
+ * Preview tab configuration
+ */
+export interface PreviewTabConfig {
+  id: PreviewTabId;
+  label: string;
+  icon: string;  // Lucide icon name
+  available: boolean;
+  content?: string;  // HTML content
+}
+
+// ============================================
+// Migration Types
+// ============================================
+
+/**
+ * Migration status for tracking data upgrades
+ */
+export interface MigrationStatus {
+  version: number;
+  lastMigrated: string;
+  migratedEntities: {
+    projects: number;
+    inspiration: number;
+    artifacts: number;
+  };
+}
+
+// ============================================
+// Utility Functions
+// ============================================
+
+/**
+ * Convert grade to grade band
+ */
+export function gradeToGradeBand(grade: Grade): GradeBand {
+  if (grade === "K" || grade === "1" || grade === "2" || grade === "3") {
+    return grade;
+  }
+  return "4-6";
+}
+
+/**
+ * Map old artifact types to new unified types
+ */
+export function mapLegacyArtifactType(legacyType: string): ArtifactType {
+  switch (legacyType) {
+    case "worksheet":
+    case "student_activity":
+      return "student_page";
+    case "lesson_plan":
+      return "lesson_plan";
+    case "answer_key":
+      return "answer_key";
+    case "teacher_script":
+      return "teacher_script";
+    default:
+      return "student_page";
+  }
+}
+
+/**
+ * Get display label for artifact type
+ */
+export function getArtifactTypeLabel(type: ArtifactType): string {
+  switch (type) {
+    case "student_page":
+      return "Student Page";
+    case "teacher_script":
+      return "Teacher Script";
+    case "answer_key":
+      return "Answer Key";
+    case "lesson_plan":
+      return "Lesson Plan";
+    case "print_pack":
+      return "Print Pack";
+  }
+}
+
+/**
+ * Get display label for project type
+ */
+export function getProjectTypeLabel(type: ProjectType): string {
+  switch (type) {
+    case "learning_path":
+      return "Learning Path";
+    case "quick_create":
+      return "Quick Create";
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 export * from "./database";
 export * from "./learner";
+export * from "./artifacts";
 
 // Project-related types
 export interface Project {


### PR DESCRIPTION
This commit implements the core infrastructure for Issue #20 - Project
Unification + Library + Objective Tagging MVP.

Key changes:
- Add new types for unified projects, artifacts, and design packs (artifacts.ts)
- Add Tauri storage commands for library, design packs, and local projects
- Add TypeScript storage services with browser fallback support
- Add Zustand stores: artifactStore, designPackStore, unifiedProjectStore
- Standardize PreviewTabs with 5 tabs: Student Page, Teacher Script,
  Answer Key, Lesson Plan, and Print Pack
- Add Library view with search, filtering, and grid/list views
- Add Design Packs panel for organizing inspiration items
- Add data migration utilities for legacy content
- Add unit tests for new stores and types

Closes #20

https://claude.ai/code/session_016JdmEuTcZ2raSGB4HF9orU