### PR TITLE
[Issue #52] Add backend local model manager with startup warmup

### DIFF
--- a/generation-api/src/__tests__/routes/health.test.ts
+++ b/generation-api/src/__tests__/routes/health.test.ts
@@ -26,4 +26,13 @@ describe("Health Route", () => {
 
     expect(response.body.version).toBeDefined();
   });
+
+  it("should return Ollama readiness fields", async () => {
+    const response = await request(app).get("/health");
+
+    expect(response.body).toHaveProperty("ollamaReachable");
+    expect(response.body).toHaveProperty("localModelReady");
+    expect(response.body).toHaveProperty("activeLocalModel");
+    expect(response.body).toHaveProperty("warmingUp");
+  });
 });

--- a/generation-api/src/__tests__/services/ollama-model-manager.test.ts
+++ b/generation-api/src/__tests__/services/ollama-model-manager.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  warmupLocalModel,
+  getOllamaWarmupState,
+  getResolvedLocalModel,
+  resetOllamaModelManagerForTests,
+} from "../../services/ollama-model-manager.js";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe("ollama-model-manager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetOllamaModelManagerForTests();
+
+    process.env.OLLAMA_PRIMARY_MODEL = "llama3.1:8b";
+    process.env.OLLAMA_FALLBACK_MODELS = "qwen2.5:7b,gemma3:4b,llama3.2";
+    process.env.OLLAMA_AUTO_PULL = "true";
+    process.env.OLLAMA_WARMUP_TIMEOUT_MS = "2000";
+  });
+
+  afterEach(() => {
+    delete process.env.OLLAMA_PRIMARY_MODEL;
+    delete process.env.OLLAMA_FALLBACK_MODELS;
+    delete process.env.OLLAMA_AUTO_PULL;
+    delete process.env.OLLAMA_WARMUP_TIMEOUT_MS;
+  });
+
+  it("selects primary model when already installed", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ models: [{ name: "llama3.1:8b" }] }),
+    });
+
+    const result = await warmupLocalModel();
+
+    expect(result.localModelReady).toBe(true);
+    expect(result.activeModel).toBe("llama3.1:8b");
+    expect(result.lastError).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to installed secondary model when primary is missing", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ models: [{ name: "gemma3:4b" }] }),
+    });
+
+    const result = await warmupLocalModel();
+
+    expect(result.localModelReady).toBe(true);
+    expect(result.activeModel).toBe("gemma3:4b");
+  });
+
+  it("pulls and activates the primary model when none are installed", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ models: [] }),
+      })
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ models: [{ name: "llama3.1:8b" }] }),
+      });
+
+    const result = await warmupLocalModel();
+
+    expect(result.localModelReady).toBe(true);
+    expect(result.activeModel).toBe("llama3.1:8b");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/pull"),
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("does not duplicate warmup execution for concurrent callers", async () => {
+    let resolveTags: ((v: unknown) => void) | null = null;
+    const delayedTagsPromise = new Promise((resolve) => {
+      resolveTags = resolve;
+    });
+
+    mockFetch.mockImplementationOnce(() => delayedTagsPromise as unknown as Promise<Response>);
+
+    const first = warmupLocalModel();
+    const second = warmupLocalModel();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    resolveTags?.({
+      ok: true,
+      json: () => Promise.resolve({ models: [{ name: "llama3.1:8b" }] }),
+    });
+
+    const [r1, r2] = await Promise.all([first, second]);
+    expect(r1.activeModel).toBe("llama3.1:8b");
+    expect(r2.activeModel).toBe("llama3.1:8b");
+  });
+
+  it("reports unreachable state when Ollama is down", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("connection refused"));
+
+    const result = await warmupLocalModel();
+    expect(result.localModelReady).toBe(false);
+    expect(result.reachable).toBe(false);
+    expect(result.activeModel).toBeNull();
+
+    const snapshot = getOllamaWarmupState();
+    expect(snapshot.localModelReady).toBe(false);
+  });
+
+  it("returns primary model as resolution fallback when warmup has not completed", () => {
+    expect(getResolvedLocalModel()).toBe("llama3.1:8b");
+  });
+});

--- a/generation-api/src/routes/health.ts
+++ b/generation-api/src/routes/health.ts
@@ -1,12 +1,19 @@
 import { Router, type Request, type Response } from "express";
+import { getOllamaWarmupState } from "../services/ollama-model-manager.js";
 
 const router = Router();
 
 router.get("/", (_req: Request, res: Response) => {
+  const ollamaState = getOllamaWarmupState();
+
   res.json({
     status: "ok",
     timestamp: new Date().toISOString(),
     version: process.env.npm_package_version || "0.1.0",
+    ollamaReachable: ollamaState.reachable,
+    localModelReady: ollamaState.localModelReady,
+    activeLocalModel: ollamaState.activeModel,
+    warmingUp: ollamaState.warmingUp,
   });
 });
 

--- a/generation-api/src/services/ollama-model-manager.ts
+++ b/generation-api/src/services/ollama-model-manager.ts
@@ -1,0 +1,295 @@
+/**
+ * Ollama Local Model Manager
+ *
+ * Startup warmup and readiness state for backend-managed local model selection.
+ */
+
+const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL || "http://localhost:11434";
+const DEFAULT_PRIMARY_MODEL = "llama3.1:8b";
+const DEFAULT_FALLBACK_MODELS = ["qwen2.5:7b", "gemma3:4b", "llama3.2"];
+
+export interface OllamaModelPolicy {
+  primaryModel: string;
+  fallbackModels: string[];
+  autoPull: boolean;
+  warmupTimeoutMs: number;
+}
+
+export interface OllamaWarmupState {
+  warmingUp: boolean;
+  reachable: boolean;
+  activeModel: string | null;
+  localModelReady: boolean;
+  selectedPrimaryModel: string;
+  fallbackModels: string[];
+  autoPull: boolean;
+  lastCheckedAt: string | null;
+  lastError: string | null;
+}
+
+const defaultState = (): OllamaWarmupState => ({
+  warmingUp: false,
+  reachable: false,
+  activeModel: null,
+  localModelReady: false,
+  selectedPrimaryModel: getModelPolicy().primaryModel,
+  fallbackModels: getModelPolicy().fallbackModels,
+  autoPull: getModelPolicy().autoPull,
+  lastCheckedAt: null,
+  lastError: null,
+});
+
+let state: OllamaWarmupState = defaultState();
+let warmupInFlight: Promise<OllamaWarmupState> | null = null;
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined) return fallback;
+  return value.toLowerCase() !== "false";
+}
+
+function parseFallbackModels(value: string | undefined): string[] {
+  if (!value || !value.trim()) return [...DEFAULT_FALLBACK_MODELS];
+  const parsed = value
+    .split(",")
+    .map((v) => v.trim())
+    .filter(Boolean);
+  return parsed.length > 0 ? parsed : [...DEFAULT_FALLBACK_MODELS];
+}
+
+export function getModelPolicy(): OllamaModelPolicy {
+  return {
+    primaryModel: process.env.OLLAMA_PRIMARY_MODEL || DEFAULT_PRIMARY_MODEL,
+    fallbackModels: parseFallbackModels(process.env.OLLAMA_FALLBACK_MODELS),
+    autoPull: parseBoolean(process.env.OLLAMA_AUTO_PULL, true),
+    warmupTimeoutMs: Number(process.env.OLLAMA_WARMUP_TIMEOUT_MS || 180000),
+  };
+}
+
+function orderedCandidates(policy: OllamaModelPolicy): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const model of [policy.primaryModel, ...policy.fallbackModels]) {
+    const normalized = model.trim();
+    if (normalized && !seen.has(normalized)) {
+      seen.add(normalized);
+      ordered.push(normalized);
+    }
+  }
+  return ordered;
+}
+
+async function getTags(): Promise<{ reachable: boolean; installed: string[] }> {
+  try {
+    const response = await fetch(`${OLLAMA_BASE_URL}/api/tags`, {
+      method: "GET",
+      signal: AbortSignal.timeout(3000),
+    });
+
+    if (!response.ok) {
+      return { reachable: false, installed: [] };
+    }
+
+    const data = await response.json();
+    const installed = (data.models || []).map((m: { name: string }) => m.name);
+    return { reachable: true, installed };
+  } catch {
+    return { reachable: false, installed: [] };
+  }
+}
+
+async function pullModel(model: string): Promise<boolean> {
+  try {
+    const response = await fetch(`${OLLAMA_BASE_URL}/api/pull`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model, stream: false }),
+      signal: AbortSignal.timeout(120000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+function selectInstalledModel(installed: string[], policy: OllamaModelPolicy): string | null {
+  const installedSet = new Set(installed);
+  for (const model of orderedCandidates(policy)) {
+    if (installedSet.has(model)) {
+      return model;
+    }
+  }
+  return null;
+}
+
+async function runWarmupInternal(): Promise<OllamaWarmupState> {
+  const policy = getModelPolicy();
+  state = {
+    ...state,
+    warmingUp: true,
+    selectedPrimaryModel: policy.primaryModel,
+    fallbackModels: policy.fallbackModels,
+    autoPull: policy.autoPull,
+    lastCheckedAt: nowIso(),
+    lastError: null,
+  };
+
+  const tags = await getTags();
+  state = { ...state, reachable: tags.reachable, lastCheckedAt: nowIso() };
+
+  if (!tags.reachable) {
+    state = {
+      ...state,
+      warmingUp: false,
+      localModelReady: false,
+      activeModel: null,
+      lastError: "Ollama is unreachable at startup",
+      lastCheckedAt: nowIso(),
+    };
+    return state;
+  }
+
+  const selectedInstalled = selectInstalledModel(tags.installed, policy);
+  if (selectedInstalled) {
+    state = {
+      ...state,
+      warmingUp: false,
+      activeModel: selectedInstalled,
+      localModelReady: true,
+      lastError: null,
+      lastCheckedAt: nowIso(),
+    };
+    return state;
+  }
+
+  if (!policy.autoPull) {
+    state = {
+      ...state,
+      warmingUp: false,
+      activeModel: null,
+      localModelReady: false,
+      lastError: "No preferred local model installed and auto-pull disabled",
+      lastCheckedAt: nowIso(),
+    };
+    return state;
+  }
+
+  for (const candidate of orderedCandidates(policy)) {
+    const pulled = await pullModel(candidate);
+    if (!pulled) {
+      state = {
+        ...state,
+        lastError: `Failed to pull model '${candidate}'`,
+      };
+      continue;
+    }
+
+    const refreshed = await getTags();
+    if (!refreshed.reachable) {
+      state = {
+        ...state,
+        warmingUp: false,
+        reachable: false,
+        activeModel: null,
+        localModelReady: false,
+        lastError: "Ollama became unreachable during warmup",
+        lastCheckedAt: nowIso(),
+      };
+      return state;
+    }
+
+    if (refreshed.installed.includes(candidate)) {
+      state = {
+        ...state,
+        warmingUp: false,
+        reachable: true,
+        activeModel: candidate,
+        localModelReady: true,
+        lastError: null,
+        lastCheckedAt: nowIso(),
+      };
+      return state;
+    }
+  }
+
+  state = {
+    ...state,
+    warmingUp: false,
+    activeModel: null,
+    localModelReady: false,
+    lastError:
+      state.lastError || "No compatible local model available after warmup attempts",
+    lastCheckedAt: nowIso(),
+  };
+
+  return state;
+}
+
+export async function warmupLocalModel(): Promise<OllamaWarmupState> {
+  if (warmupInFlight) return warmupInFlight;
+
+  const { warmupTimeoutMs } = getModelPolicy();
+  warmupInFlight = new Promise<OllamaWarmupState>((resolve) => {
+    let settled = false;
+    const finish = (nextState: OllamaWarmupState) => {
+      if (settled) return;
+      settled = true;
+      resolve(nextState);
+    };
+
+    const timeoutId = setTimeout(() => {
+      state = {
+        ...state,
+        warmingUp: false,
+        localModelReady: false,
+        activeModel: null,
+        lastError: `Warmup timed out after ${warmupTimeoutMs}ms`,
+        lastCheckedAt: nowIso(),
+      };
+      finish(state);
+    }, warmupTimeoutMs);
+
+    void runWarmupInternal()
+      .then((result) => {
+        clearTimeout(timeoutId);
+        finish(result);
+      })
+      .catch((error) => {
+        clearTimeout(timeoutId);
+        state = {
+          ...state,
+          warmingUp: false,
+          localModelReady: false,
+          activeModel: null,
+          lastError: error instanceof Error ? error.message : String(error),
+          lastCheckedAt: nowIso(),
+        };
+        finish(state);
+      });
+  }).finally(() => {
+    warmupInFlight = null;
+  });
+
+  return warmupInFlight;
+}
+
+export function getOllamaWarmupState(): OllamaWarmupState {
+  return { ...state };
+}
+
+export function getResolvedLocalModel(): string {
+  if (!state.localModelReady || !state.activeModel) {
+    const policy = getModelPolicy();
+    return policy.primaryModel;
+  }
+  return state.activeModel;
+}
+
+// Test helper
+export function resetOllamaModelManagerForTests(): void {
+  state = defaultState();
+  warmupInFlight = null;
+}


### PR DESCRIPTION
## Summary\n- add Ollama local model manager with primary/fallback policy and readiness state\n- add startup warmup flow in generation API boot path\n- extend health endpoint with local-model readiness fields\n- add unit tests for warmup, fallback, pull flow, and concurrency guard\n\n## Validation\n- cd generation-api && npm run test:run -- src/__tests__/services/ollama-model-manager.test.ts src/__tests__/routes/health.test.ts\n\nCloses #52