### PR TITLE
[Issue #54] Remove header and first-run Local AI setup UX

### DIFF
--- a/src/__tests__/components/layout/AppLayout.test.tsx
+++ b/src/__tests__/components/layout/AppLayout.test.tsx
@@ -1,14 +1,11 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
 import { AppLayout } from "@/components/layout/AppLayout";
 
 // Mock tauri-bridge
-const mockCheckOllamaStatus = vi.fn();
 const mockCheckForUpdates = vi.fn();
 const mockDownloadAndInstallUpdate = vi.fn();
 vi.mock("@/services/tauri-bridge", () => ({
-  checkOllamaStatus: () => mockCheckOllamaStatus(),
   checkForUpdates: () => mockCheckForUpdates(),
   downloadAndInstallUpdate: () => mockDownloadAndInstallUpdate(),
 }));
@@ -22,41 +19,21 @@ vi.mock("@/components/layout/Sidebar", () => ({
   Sidebar: () => <aside data-testid="sidebar">Sidebar</aside>,
 }));
 
-// Mock OllamaSetup and UpdateDialog to capture open state
-const mockOnOpenChange = vi.fn();
 vi.mock("@/components/settings", () => ({
-  OllamaSetup: ({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) => {
-    // Store the callback for testing
-    mockOnOpenChange.mockImplementation(onOpenChange);
-    return open ? (
-      <div data-testid="ollama-setup-dialog" role="dialog">
-        <button onClick={() => onOpenChange(false)}>Close</button>
-      </div>
-    ) : null;
-  },
   UpdateDialog: ({ open }: { open: boolean }) => {
     return open ? <div data-testid="update-dialog" role="dialog">Update Dialog</div> : null;
   },
 }));
 
 describe("AppLayout", () => {
-  const OLLAMA_SETUP_SEEN_KEY = "ta-ollama-setup-seen";
-
   beforeEach(() => {
     vi.clearAllMocks();
-    localStorage.clear();
     // Default: no updates available
     mockCheckForUpdates.mockResolvedValue({ available: false });
   });
 
-  afterEach(() => {
-    localStorage.clear();
-  });
-
   describe("basic rendering", () => {
     it("renders Header component", () => {
-      mockCheckOllamaStatus.mockRejectedValue(new Error("Not in Tauri"));
-
       render(
         <AppLayout>
           <div>Content</div>
@@ -67,8 +44,6 @@ describe("AppLayout", () => {
     });
 
     it("renders Sidebar component", () => {
-      mockCheckOllamaStatus.mockRejectedValue(new Error("Not in Tauri"));
-
       render(
         <AppLayout>
           <div>Content</div>
@@ -79,8 +54,6 @@ describe("AppLayout", () => {
     });
 
     it("renders main content area with children", () => {
-      mockCheckOllamaStatus.mockRejectedValue(new Error("Not in Tauri"));
-
       render(
         <AppLayout>
           <div data-testid="child-content">Child Content</div>
@@ -92,8 +65,6 @@ describe("AppLayout", () => {
     });
 
     it("applies correct layout structure", () => {
-      mockCheckOllamaStatus.mockRejectedValue(new Error("Not in Tauri"));
-
       const { container } = render(
         <AppLayout>
           <div>Content</div>
@@ -106,131 +77,8 @@ describe("AppLayout", () => {
     });
   });
 
-  describe("first-run Ollama setup", () => {
-    it("shows Ollama setup when not installed on first run", async () => {
-      mockCheckOllamaStatus.mockResolvedValue({
-        installed: false,
-        running: false,
-        models: [],
-      });
-
-      render(
-        <AppLayout>
-          <div>Content</div>
-        </AppLayout>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByTestId("ollama-setup-dialog")).toBeInTheDocument();
-      });
-    });
-
-    it("shows Ollama setup when installed but no models on first run", async () => {
-      mockCheckOllamaStatus.mockResolvedValue({
-        installed: true,
-        running: true,
-        models: [],
-      });
-
-      render(
-        <AppLayout>
-          <div>Content</div>
-        </AppLayout>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByTestId("ollama-setup-dialog")).toBeInTheDocument();
-      });
-    });
-
-    it("does not show Ollama setup when installed with models", async () => {
-      mockCheckOllamaStatus.mockResolvedValue({
-        installed: true,
-        running: true,
-        models: ["llama3.2"],
-      });
-
-      render(
-        <AppLayout>
-          <div>Content</div>
-        </AppLayout>
-      );
-
-      // Wait a bit to ensure the effect has run
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      expect(screen.queryByTestId("ollama-setup-dialog")).not.toBeInTheDocument();
-    });
-
-    it("does not show Ollama setup if user has already seen it", async () => {
-      localStorage.setItem(OLLAMA_SETUP_SEEN_KEY, "true");
-
-      mockCheckOllamaStatus.mockResolvedValue({
-        installed: false,
-        running: false,
-        models: [],
-      });
-
-      render(
-        <AppLayout>
-          <div>Content</div>
-        </AppLayout>
-      );
-
-      // Wait a bit to ensure the effect has run
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      expect(screen.queryByTestId("ollama-setup-dialog")).not.toBeInTheDocument();
-      // Should not even call checkOllamaStatus when setup was already seen
-      expect(mockCheckOllamaStatus).not.toHaveBeenCalled();
-    });
-
-    it("does not show Ollama setup when check fails (non-Tauri context)", async () => {
-      mockCheckOllamaStatus.mockRejectedValue(new Error("Not in Tauri context"));
-
-      render(
-        <AppLayout>
-          <div>Content</div>
-        </AppLayout>
-      );
-
-      // Wait a bit to ensure the effect has run
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      expect(screen.queryByTestId("ollama-setup-dialog")).not.toBeInTheDocument();
-    });
-
-    it("marks setup as seen when dialog is closed", async () => {
-      mockCheckOllamaStatus.mockResolvedValue({
-        installed: false,
-        running: false,
-        models: [],
-      });
-
-      const user = userEvent.setup();
-
-      render(
-        <AppLayout>
-          <div>Content</div>
-        </AppLayout>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByTestId("ollama-setup-dialog")).toBeInTheDocument();
-      });
-
-      // Close the dialog
-      await user.click(screen.getByRole("button", { name: "Close" }));
-
-      // Check localStorage was updated
-      expect(localStorage.getItem(OLLAMA_SETUP_SEEN_KEY)).toBe("true");
-    });
-  });
-
   describe("layout accessibility", () => {
     it("has a main landmark", () => {
-      mockCheckOllamaStatus.mockRejectedValue(new Error("Not in Tauri"));
-
       render(
         <AppLayout>
           <div>Content</div>
@@ -241,8 +89,6 @@ describe("AppLayout", () => {
     });
 
     it("renders content in correct order (header, sidebar, main)", () => {
-      mockCheckOllamaStatus.mockRejectedValue(new Error("Not in Tauri"));
-
       const { container } = render(
         <AppLayout>
           <div>Content</div>

--- a/src/__tests__/components/layout/Header.test.tsx
+++ b/src/__tests__/components/layout/Header.test.tsx
@@ -13,20 +13,6 @@ vi.mock("@/hooks/useAuth", () => ({
   }),
 }));
 
-// Mock settings components
-vi.mock("@/components/settings", () => ({
-  OllamaSetup: ({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) => {
-    return open ? (
-      <div data-testid="ollama-setup-dialog" role="dialog">
-        <button onClick={() => onOpenChange(false)}>Close Setup</button>
-      </div>
-    ) : null;
-  },
-  UpdateDialog: ({ open }: { open: boolean }) => {
-    return open ? <div data-testid="update-dialog" role="dialog">Update Dialog</div> : null;
-  },
-}));
-
 // Mock purchase components
 vi.mock("@/components/purchase", () => ({
   PurchaseDialog: ({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) => {
@@ -88,39 +74,6 @@ describe("Header", () => {
     });
   });
 
-  describe("settings button", () => {
-    it("renders settings button with correct title", () => {
-      render(<Header />);
-
-      const settingsButton = screen.getByTitle("Local AI Setup");
-      expect(settingsButton).toBeInTheDocument();
-    });
-
-    it("opens Ollama setup dialog when clicked", async () => {
-      const user = userEvent.setup();
-      render(<Header />);
-
-      const settingsButton = screen.getByTitle("Local AI Setup");
-      await user.click(settingsButton);
-
-      expect(screen.getByTestId("ollama-setup-dialog")).toBeInTheDocument();
-    });
-
-    it("closes Ollama setup dialog when close is triggered", async () => {
-      const user = userEvent.setup();
-      render(<Header />);
-
-      // Open the dialog
-      const settingsButton = screen.getByTitle("Local AI Setup");
-      await user.click(settingsButton);
-      expect(screen.getByTestId("ollama-setup-dialog")).toBeInTheDocument();
-
-      // Close the dialog
-      await user.click(screen.getByRole("button", { name: "Close Setup" }));
-      expect(screen.queryByTestId("ollama-setup-dialog")).not.toBeInTheDocument();
-    });
-  });
-
   describe("user info", () => {
     it("displays user email", () => {
       render(<Header />);
@@ -156,7 +109,6 @@ describe("Header", () => {
     it("buttons have accessible names via title attributes", () => {
       render(<Header />);
 
-      expect(screen.getByTitle("Local AI Setup")).toBeInTheDocument();
       expect(screen.getByTitle("Sign out")).toBeInTheDocument();
     });
   });

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,9 +1,8 @@
 import { ReactNode, useState, useEffect } from "react";
 import { Header } from "./Header";
 import { Sidebar } from "./Sidebar";
-import { OllamaSetup, UpdateDialog } from "@/components/settings";
+import { UpdateDialog } from "@/components/settings";
 import {
-  checkOllamaStatus,
   checkForUpdates,
   downloadAndInstallUpdate,
   type UpdateInfo,
@@ -13,10 +12,7 @@ interface AppLayoutProps {
   children: ReactNode;
 }
 
-const OLLAMA_SETUP_SEEN_KEY = "ta-ollama-setup-seen";
-
 export function AppLayout({ children }: AppLayoutProps) {
-  const [showOllamaSetup, setShowOllamaSetup] = useState(false);
   const [showUpdateDialog, setShowUpdateDialog] = useState(false);
   const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
 
@@ -37,36 +33,6 @@ export function AppLayout({ children }: AppLayoutProps) {
     checkUpdates();
   }, []);
 
-  useEffect(() => {
-    // Check if user has already seen the Ollama setup
-    const setupSeen = localStorage.getItem(OLLAMA_SETUP_SEEN_KEY);
-    if (setupSeen) return;
-
-    // Check Ollama status on first run
-    const checkFirstRun = async () => {
-      try {
-        const status = await checkOllamaStatus();
-        // Show setup if Ollama is installed but has no models
-        // or if not installed at all
-        if (!status.installed || (status.installed && status.models.length === 0)) {
-          setShowOllamaSetup(true);
-        }
-      } catch {
-        // If check fails, don't show the dialog (might not be in Tauri context)
-      }
-    };
-
-    checkFirstRun();
-  }, []);
-
-  const handleSetupClose = (open: boolean) => {
-    setShowOllamaSetup(open);
-    if (!open) {
-      // Mark as seen when user closes the dialog
-      localStorage.setItem(OLLAMA_SETUP_SEEN_KEY, "true");
-    }
-  };
-
   return (
     <div className="min-h-screen bg-background flex flex-col">
       <Header />
@@ -74,9 +40,6 @@ export function AppLayout({ children }: AppLayoutProps) {
         <Sidebar />
         <main className="flex-1 overflow-auto p-6">{children}</main>
       </div>
-
-      {/* First-run Ollama setup dialog */}
-      <OllamaSetup open={showOllamaSetup} onOpenChange={handleSetupClose} />
 
       {/* Update available dialog */}
       <UpdateDialog

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -7,15 +7,13 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { LogOut, Coins, GraduationCap, User, Settings } from "lucide-react";
-import { OllamaSetup } from "@/components/settings";
+import { LogOut, Coins, GraduationCap, User } from "lucide-react";
 import { FeedbackButton } from "@/components/feedback";
 import { PurchaseDialog } from "@/components/purchase";
 import { LearnerSwitcher } from "@/components/learner";
 
 export function Header() {
   const { profile, credits, signOut } = useAuth();
-  const [ollamaSetupOpen, setOllamaSetupOpen] = useState(false);
   const [purchaseDialogOpen, setPurchaseDialogOpen] = useState(false);
 
   // Always show credits badge when available (users may switch between Premium and Local AI)
@@ -70,16 +68,6 @@ export function Header() {
           {/* Learner Switcher */}
           <LearnerSwitcher compact />
 
-          {/* Settings */}
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => setOllamaSetupOpen(true)}
-            title="Local AI Setup"
-          >
-            <Settings className="h-4 w-4" />
-          </Button>
-
           {/* Feedback */}
           <FeedbackButton />
 
@@ -102,9 +90,6 @@ export function Header() {
           </div>
         </div>
       </div>
-
-      {/* Ollama Setup Dialog */}
-      <OllamaSetup open={ollamaSetupOpen} onOpenChange={setOllamaSetupOpen} />
 
       {/* Purchase Dialog */}
       <PurchaseDialog

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -1,2 +1,1 @@
-export { OllamaSetup } from "./OllamaSetup";
 export { UpdateDialog } from "./UpdateDialog";


### PR DESCRIPTION
## Summary\n- remove Local AI setup trigger and dialog from header\n- remove first-run Ollama setup popup flow from app layout\n- remove dead settings index export for OllamaSetup\n- update Header and AppLayout tests for the new behavior\n\n## Validation\n- npm run test:run -- src/__tests__/components/layout/Header.test.tsx src/__tests__/components/layout/AppLayout.test.tsx\n\nCloses #54