### PR TITLE
[Issue #55] [FEATURE] Remove wizard local model selector and model-dependent gating

### DIFF
--- a/src/__tests__/components/wizard/AIProviderStep.test.tsx
+++ b/src/__tests__/components/wizard/AIProviderStep.test.tsx
@@ -4,18 +4,15 @@ import userEvent from "@testing-library/user-event";
 import { AIProviderStep } from "@/components/wizard/AIProviderStep";
 import { useWizardStore } from "@/stores/wizardStore";
 
-// Mock the ProviderSelector component to avoid complex Ollama API mocking
+let mockCreditsBalance = 50;
+
 vi.mock("@/components/wizard/ProviderSelector", () => ({
   ProviderSelector: ({
     value,
     onChange,
-    ollamaModel,
-    onOllamaModelChange,
   }: {
     value: string;
     onChange: (value: string) => void;
-    ollamaModel: string | null;
-    onOllamaModelChange: (value: string | null) => void;
   }) => (
     <div data-testid="provider-selector">
       <select
@@ -26,31 +23,17 @@ vi.mock("@/components/wizard/ProviderSelector", () => ({
         <option value="premium">Premium AI</option>
         <option value="local">Local AI</option>
       </select>
-      {value === "local" && (
-        <select
-          data-testid="model-select"
-          value={ollamaModel || ""}
-          onChange={(e) => onOllamaModelChange(e.target.value || null)}
-        >
-          <option value="">Select a model</option>
-          <option value="llama3.2">llama3.2</option>
-          <option value="mistral">mistral</option>
-        </select>
-      )}
     </div>
   ),
 }));
 
-// Mock useAuth hook
-const mockRefreshCredits = vi.fn();
 vi.mock("@/hooks/useAuth", () => ({
   useAuth: () => ({
-    credits: { balance: 50, lifetimeGranted: 50, lifetimeUsed: 0 },
-    refreshCredits: mockRefreshCredits,
+    credits: { balance: mockCreditsBalance, lifetimeGranted: 50, lifetimeUsed: 0 },
+    refreshCredits: vi.fn(),
   }),
 }));
 
-// Mock PurchaseDialog to avoid complex component testing
 vi.mock("@/components/purchase", () => ({
   PurchaseDialog: ({ open }: { open: boolean }) =>
     open ? <div data-testid="purchase-dialog">Purchase Dialog</div> : null,
@@ -60,224 +43,98 @@ describe("AIProviderStep", () => {
   const mockNextStep = vi.fn();
   const mockPrevStep = vi.fn();
   const mockSetAiProvider = vi.fn();
-  const mockSetOllamaModel = vi.fn();
+  const mockSetVisualSettings = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCreditsBalance = 50;
+
     useWizardStore.setState({
       aiProvider: "premium",
-      ollamaModel: null,
       nextStep: mockNextStep,
       prevStep: mockPrevStep,
       setAiProvider: mockSetAiProvider,
-      setOllamaModel: mockSetOllamaModel,
+      visualSettings: {
+        includeVisuals: true,
+        richness: "minimal",
+        style: "friendly_cartoon",
+      },
+      setVisualSettings: mockSetVisualSettings,
+      classDetails: {
+        grade: "2",
+        subject: "Math",
+        format: "worksheet",
+        questionCount: 10,
+        includeVisuals: true,
+        difficulty: "medium",
+        includeAnswerKey: true,
+        lessonLength: 30,
+        studentProfile: [],
+        teachingConfidence: "intermediate",
+      },
       selectedInspiration: [],
     });
   });
 
-  it("renders the AI provider selector", () => {
+  it("renders provider selector and controls", () => {
     render(<AIProviderStep />);
 
     expect(screen.getByTestId("provider-selector")).toBeInTheDocument();
-    expect(screen.getByText(/AI Provider/i)).toBeInTheDocument();
-  });
-
-  it("renders the description text", () => {
-    render(<AIProviderStep />);
-
-    expect(
-      screen.getByText(/Choose which AI will generate your teaching materials/i)
-    ).toBeInTheDocument();
-  });
-
-  it("renders Back button", () => {
-    render(<AIProviderStep />);
-
     expect(screen.getByRole("button", { name: /back/i })).toBeInTheDocument();
-  });
-
-  it("renders Next button", () => {
-    render(<AIProviderStep />);
-
     expect(screen.getByRole("button", { name: /next/i })).toBeInTheDocument();
   });
 
-  it("shows Premium AI as default selected provider", () => {
+  it("shows Premium AI as default provider", () => {
     render(<AIProviderStep />);
-
-    const providerSelect = screen.getByTestId("provider-select");
-    expect(providerSelect).toHaveValue("premium");
+    expect(screen.getByTestId("provider-select")).toHaveValue("premium");
   });
 
   it("calls setAiProvider when provider is changed", async () => {
     const user = userEvent.setup();
     render(<AIProviderStep />);
 
-    const providerSelect = screen.getByTestId("provider-select");
-    await user.selectOptions(providerSelect, "local");
-
+    await user.selectOptions(screen.getByTestId("provider-select"), "local");
     expect(mockSetAiProvider).toHaveBeenCalledWith("local");
   });
 
-  it("enables Next button when Premium AI is selected with sufficient credits", () => {
-    useWizardStore.setState({ aiProvider: "premium", ollamaModel: null });
+  it("allows continuing with Local AI without model selection", () => {
+    useWizardStore.setState({ aiProvider: "local" });
     render(<AIProviderStep />);
 
-    const nextButton = screen.getByRole("button", { name: /next/i });
-    expect(nextButton).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: /next/i })).not.toBeDisabled();
   });
 
-  it("disables Next button when Local AI is selected but no model is chosen", () => {
-    useWizardStore.setState({ aiProvider: "local", ollamaModel: null });
+  it("blocks Premium AI when credits are insufficient", () => {
+    mockCreditsBalance = 0;
     render(<AIProviderStep />);
 
-    const nextButton = screen.getByRole("button", { name: /next/i });
-    expect(nextButton).toBeDisabled();
+    expect(
+      screen.getByText(/Insufficient credits for Premium AI/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /next/i })).toBeDisabled();
   });
 
-  it("enables Next button when Local AI is selected with a model", () => {
-    useWizardStore.setState({ aiProvider: "local", ollamaModel: "llama3.2" });
+  it("shows local design warning when visual inspiration exists", () => {
+    useWizardStore.setState({
+      aiProvider: "local",
+      selectedInspiration: [
+        { id: "img-1", type: "image", title: "design.png", content: "base64" },
+      ],
+    });
+
     render(<AIProviderStep />);
 
-    const nextButton = screen.getByRole("button", { name: /next/i });
-    expect(nextButton).not.toBeDisabled();
+    expect(screen.getByText(/Design inspiration will be limited/i)).toBeInTheDocument();
   });
 
-  it("calls prevStep when Back button is clicked", async () => {
+  it("calls prevStep and nextStep from buttons", async () => {
     const user = userEvent.setup();
     render(<AIProviderStep />);
 
-    const backButton = screen.getByRole("button", { name: /back/i });
-    await user.click(backButton);
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
 
     expect(mockPrevStep).toHaveBeenCalledTimes(1);
-  });
-
-  it("calls nextStep when Next button is clicked", async () => {
-    const user = userEvent.setup();
-    render(<AIProviderStep />);
-
-    const nextButton = screen.getByRole("button", { name: /next/i });
-    await user.click(nextButton);
-
     expect(mockNextStep).toHaveBeenCalledTimes(1);
-  });
-
-  it("shows model selector when Local AI is selected", () => {
-    useWizardStore.setState({ aiProvider: "local", ollamaModel: null });
-    render(<AIProviderStep />);
-
-    expect(screen.getByTestId("model-select")).toBeInTheDocument();
-  });
-
-  it("does not show model selector when Premium AI is selected", () => {
-    useWizardStore.setState({ aiProvider: "premium", ollamaModel: null });
-    render(<AIProviderStep />);
-
-    expect(screen.queryByTestId("model-select")).not.toBeInTheDocument();
-  });
-
-  it("calls setOllamaModel when model is changed", async () => {
-    useWizardStore.setState({ aiProvider: "local", ollamaModel: null });
-    const user = userEvent.setup();
-    render(<AIProviderStep />);
-
-    const modelSelect = screen.getByTestId("model-select");
-    await user.selectOptions(modelSelect, "llama3.2");
-
-    expect(mockSetOllamaModel).toHaveBeenCalledWith("llama3.2");
-  });
-
-  describe("Design inspiration warning", () => {
-    const imageInspiration = [
-      { id: "img-1", type: "image" as const, title: "design.png", content: "base64..." },
-    ];
-    const urlInspiration = [
-      { id: "url-1", type: "url" as const, title: "example.com", sourceUrl: "https://example.com" },
-    ];
-    const pdfInspiration = [
-      { id: "pdf-1", type: "pdf" as const, title: "worksheet.pdf", content: "base64..." },
-    ];
-    const textOnlyInspiration = [
-      { id: "text-1", type: "text" as const, title: "Notes", content: "Some text notes" },
-    ];
-
-    it("does not show warning when Premium AI is selected with design inspiration", () => {
-      useWizardStore.setState({
-        aiProvider: "premium",
-        ollamaModel: null,
-        selectedInspiration: imageInspiration,
-      });
-      render(<AIProviderStep />);
-
-      expect(screen.queryByText(/Design inspiration will be limited/i)).not.toBeInTheDocument();
-    });
-
-    it("does not show warning when Local AI is selected with text-only inspiration", () => {
-      useWizardStore.setState({
-        aiProvider: "local",
-        ollamaModel: "llama3.2",
-        selectedInspiration: textOnlyInspiration,
-      });
-      render(<AIProviderStep />);
-
-      expect(screen.queryByText(/Design inspiration will be limited/i)).not.toBeInTheDocument();
-    });
-
-    it("does not show warning when Local AI is selected with no inspiration", () => {
-      useWizardStore.setState({
-        aiProvider: "local",
-        ollamaModel: "llama3.2",
-        selectedInspiration: [],
-      });
-      render(<AIProviderStep />);
-
-      expect(screen.queryByText(/Design inspiration will be limited/i)).not.toBeInTheDocument();
-    });
-
-    it("shows warning when Local AI is selected with image inspiration", () => {
-      useWizardStore.setState({
-        aiProvider: "local",
-        ollamaModel: "llama3.2",
-        selectedInspiration: imageInspiration,
-      });
-      render(<AIProviderStep />);
-
-      expect(screen.getByText(/Design inspiration will be limited/i)).toBeInTheDocument();
-      expect(screen.getByText(/Local AI cannot analyze visual designs/i)).toBeInTheDocument();
-    });
-
-    it("shows warning when Local AI is selected with URL inspiration", () => {
-      useWizardStore.setState({
-        aiProvider: "local",
-        ollamaModel: "llama3.2",
-        selectedInspiration: urlInspiration,
-      });
-      render(<AIProviderStep />);
-
-      expect(screen.getByText(/Design inspiration will be limited/i)).toBeInTheDocument();
-    });
-
-    it("shows warning when Local AI is selected with PDF inspiration", () => {
-      useWizardStore.setState({
-        aiProvider: "local",
-        ollamaModel: "llama3.2",
-        selectedInspiration: pdfInspiration,
-      });
-      render(<AIProviderStep />);
-
-      expect(screen.getByText(/Design inspiration will be limited/i)).toBeInTheDocument();
-    });
-
-    it("shows warning when Local AI is selected with mixed design inspiration", () => {
-      useWizardStore.setState({
-        aiProvider: "local",
-        ollamaModel: "llama3.2",
-        selectedInspiration: [...textOnlyInspiration, ...imageInspiration, ...urlInspiration],
-      });
-      render(<AIProviderStep />);
-
-      expect(screen.getByText(/Design inspiration will be limited/i)).toBeInTheDocument();
-    });
   });
 });

--- a/src/__tests__/components/wizard/GenerationStep.test.tsx
+++ b/src/__tests__/components/wizard/GenerationStep.test.tsx
@@ -281,6 +281,22 @@ describe("GenerationStep", () => {
     expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
   });
 
+  it("does not send aiModel when using Local AI", async () => {
+    useWizardStore.setState({
+      aiProvider: "local",
+    });
+
+    render(<GenerationStep />);
+
+    await waitFor(() => {
+      expect(generateTeacherPack).toHaveBeenCalled();
+    }, { timeout: 5000 });
+
+    const request = vi.mocked(generateTeacherPack).mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(request.aiProvider).toBe("local");
+    expect(Object.prototype.hasOwnProperty.call(request, "aiModel")).toBe(false);
+  });
+
   describe("store synchronization after generation", () => {
     const mockFetchProjectVersion = vi.fn();
 

--- a/src/__tests__/components/wizard/ProviderSelector.test.tsx
+++ b/src/__tests__/components/wizard/ProviderSelector.test.tsx
@@ -1,284 +1,55 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ProviderSelector } from "@/components/wizard/ProviderSelector";
-
-// Mock the tauri-bridge module
-const mockCheckOllamaStatus = vi.fn();
-
-vi.mock("@/services/tauri-bridge", () => ({
-  checkOllamaStatus: () => mockCheckOllamaStatus(),
-}));
 
 describe("ProviderSelector", () => {
   const defaultProps = {
     value: "premium" as const,
     onChange: vi.fn(),
-    ollamaModel: null,
-    onOllamaModelChange: vi.fn(),
   };
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockCheckOllamaStatus.mockResolvedValue({
-      installed: true,
-      running: true,
-      version: "0.1.0",
-      models: ["llama3.2", "mistral"],
-    });
+  it("renders both provider options", () => {
+    render(<ProviderSelector {...defaultProps} />);
+
+    expect(screen.getByText("Premium AI")).toBeInTheDocument();
+    expect(screen.getByText("Local AI")).toBeInTheDocument();
   });
 
-  describe("rendering", () => {
-    it("renders both provider options", async () => {
-      render(<ProviderSelector {...defaultProps} />);
+  it("shows provider descriptions and badges", () => {
+    render(<ProviderSelector {...defaultProps} />);
 
-      expect(screen.getByText("Premium AI")).toBeInTheDocument();
-      expect(screen.getByText("Local AI")).toBeInTheDocument();
-    });
-
-    it("renders Premium AI with Best Quality badge", async () => {
-      render(<ProviderSelector {...defaultProps} />);
-
-      expect(screen.getByText("Best Quality")).toBeInTheDocument();
-    });
-
-    it("renders Local AI with Free badge", async () => {
-      render(<ProviderSelector {...defaultProps} />);
-
-      expect(screen.getByText("Free")).toBeInTheDocument();
-    });
-
-    it("shows provider descriptions", async () => {
-      render(<ProviderSelector {...defaultProps} />);
-
-      expect(screen.getByText(/Best quality - uses cloud-based AI/)).toBeInTheDocument();
-      expect(screen.getByText(/Runs on this computer - no image analysis/)).toBeInTheDocument();
-    });
-
-    it("shows credits info for Premium AI", async () => {
-      render(<ProviderSelector {...defaultProps} />);
-
-      expect(screen.getByText(/Uses credits \(typically 3-6 per worksheet\)/)).toBeInTheDocument();
-    });
+    expect(screen.getByText(/Best quality - uses cloud-based AI/i)).toBeInTheDocument();
+    expect(screen.getByText(/Runs on this computer - no image analysis/i)).toBeInTheDocument();
+    expect(screen.getByText("Best Quality")).toBeInTheDocument();
+    expect(screen.getByText("Free")).toBeInTheDocument();
   });
 
-  describe("provider selection", () => {
-    it("calls onChange when Premium AI is clicked", async () => {
-      const onChange = vi.fn();
-      const user = userEvent.setup();
+  it("shows backend-managed local model note", () => {
+    render(<ProviderSelector {...defaultProps} />);
 
-      render(<ProviderSelector {...defaultProps} value="local" onChange={onChange} />);
-
-      await user.click(screen.getByText("Premium AI").closest("[role='button']")!);
-
-      expect(onChange).toHaveBeenCalledWith("premium");
-    });
-
-    it("calls onChange when Local AI is clicked", async () => {
-      const onChange = vi.fn();
-      const user = userEvent.setup();
-
-      render(<ProviderSelector {...defaultProps} onChange={onChange} />);
-
-      await user.click(screen.getByText("Local AI").closest("[role='button']")!);
-
-      expect(onChange).toHaveBeenCalledWith("local");
-    });
+    expect(
+      screen.getByText(/Model selection is managed automatically by the backend/i)
+    ).toBeInTheDocument();
   });
 
-  describe("Local AI status", () => {
-    it("shows Ready status when Local AI is available with models", async () => {
-      render(<ProviderSelector {...defaultProps} />);
+  it("calls onChange when Premium AI is clicked", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
 
-      await waitFor(() => {
-        expect(screen.getByText("Ready (2 models available)")).toBeInTheDocument();
-      });
-    });
+    render(<ProviderSelector {...defaultProps} value="local" onChange={onChange} />);
+    await user.click(screen.getByText("Premium AI").closest("[role='button']")!);
 
-    it("shows No models installed when Local AI is running but has no models", async () => {
-      mockCheckOllamaStatus.mockResolvedValue({
-        installed: true,
-        running: true,
-        version: "0.1.0",
-        models: [],
-      });
-
-      render(<ProviderSelector {...defaultProps} />);
-
-      await waitFor(() => {
-        expect(screen.getByText("No models installed")).toBeInTheDocument();
-      });
-    });
-
-    it("shows Not running when Local AI is not running", async () => {
-      mockCheckOllamaStatus.mockResolvedValue({
-        installed: true,
-        running: false,
-        version: null,
-        models: [],
-      });
-
-      render(<ProviderSelector {...defaultProps} />);
-
-      await waitFor(() => {
-        expect(screen.getByText("Not running")).toBeInTheDocument();
-      });
-    });
-
-    it("shows Checking status initially", async () => {
-      mockCheckOllamaStatus.mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 100))
-      );
-
-      render(<ProviderSelector {...defaultProps} />);
-
-      expect(screen.getByText(/Checking local AI status/)).toBeInTheDocument();
-    });
+    expect(onChange).toHaveBeenCalledWith("premium");
   });
 
-  describe("Local AI model selection", () => {
-    it("shows model dropdown when Local AI is selected and running", async () => {
-      render(<ProviderSelector {...defaultProps} value="local" />);
+  it("calls onChange when Local AI is clicked", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
 
-      await waitFor(() => {
-        expect(screen.getByText("Local AI Model")).toBeInTheDocument();
-      });
-    });
+    render(<ProviderSelector {...defaultProps} onChange={onChange} />);
+    await user.click(screen.getByText("Local AI").closest("[role='button']")!);
 
-    it("does not show model dropdown when Premium AI is selected", async () => {
-      render(<ProviderSelector {...defaultProps} value="premium" />);
-
-      await waitFor(() => {
-        expect(screen.queryByText("Local AI Model")).not.toBeInTheDocument();
-      });
-    });
-
-    it("does not show model dropdown when Local AI is not running", async () => {
-      mockCheckOllamaStatus.mockResolvedValue({
-        installed: true,
-        running: false,
-        version: null,
-        models: [],
-      });
-
-      render(<ProviderSelector {...defaultProps} value="local" />);
-
-      await waitFor(() => {
-        expect(screen.queryByText("Local AI Model")).not.toBeInTheDocument();
-      });
-    });
-
-    it("auto-selects first model when switching to Local AI", async () => {
-      const onOllamaModelChange = vi.fn();
-      const onChange = vi.fn();
-      const user = userEvent.setup();
-
-      render(
-        <ProviderSelector
-          {...defaultProps}
-          onChange={onChange}
-          onOllamaModelChange={onOllamaModelChange}
-        />
-      );
-
-      // Wait for Local AI status to load
-      await waitFor(() => {
-        expect(screen.getByText("Ready (2 models available)")).toBeInTheDocument();
-      });
-
-      // Click Local AI
-      await user.click(screen.getByText("Local AI").closest("[role='button']")!);
-
-      expect(onOllamaModelChange).toHaveBeenCalledWith("llama3.2");
-    });
-
-    it("clears model when switching away from Local AI", async () => {
-      const onOllamaModelChange = vi.fn();
-      const user = userEvent.setup();
-
-      render(
-        <ProviderSelector
-          {...defaultProps}
-          value="local"
-          ollamaModel="llama3.2"
-          onOllamaModelChange={onOllamaModelChange}
-        />
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText("Local AI Model")).toBeInTheDocument();
-      });
-
-      // Click Premium AI
-      await user.click(screen.getByText("Premium AI").closest("[role='button']")!);
-
-      expect(onOllamaModelChange).toHaveBeenCalledWith(null);
-    });
-  });
-
-  describe("warning messages", () => {
-    it("shows warning when Local AI is selected but not running", async () => {
-      mockCheckOllamaStatus.mockResolvedValue({
-        installed: true,
-        running: false,
-        version: null,
-        models: [],
-      });
-
-      render(<ProviderSelector {...defaultProps} value="local" />);
-
-      await waitFor(() => {
-        expect(
-          screen.getByText(/Local AI is not running/i)
-        ).toBeInTheDocument();
-      });
-    });
-
-    it("shows warning when Local AI is selected but no models installed", async () => {
-      mockCheckOllamaStatus.mockResolvedValue({
-        installed: true,
-        running: true,
-        version: "0.1.0",
-        models: [],
-      });
-
-      render(<ProviderSelector {...defaultProps} value="local" />);
-
-      await waitFor(() => {
-        // Warning message in the amber box
-        expect(
-          screen.getByText(/Install a model from Settings/i)
-        ).toBeInTheDocument();
-      });
-    });
-
-    it("does not show warning when Premium AI is selected", async () => {
-      mockCheckOllamaStatus.mockResolvedValue({
-        installed: true,
-        running: false,
-        version: null,
-        models: [],
-      });
-
-      render(<ProviderSelector {...defaultProps} value="premium" />);
-
-      await waitFor(() => {
-        expect(
-          screen.queryByText(/Local AI is not running/i)
-        ).not.toBeInTheDocument();
-      });
-    });
-  });
-
-  describe("error handling", () => {
-    it("handles Local AI check failure gracefully", async () => {
-      mockCheckOllamaStatus.mockRejectedValue(new Error("Connection failed"));
-
-      render(<ProviderSelector {...defaultProps} />);
-
-      await waitFor(() => {
-        expect(screen.getByText("Not running")).toBeInTheDocument();
-      });
-    });
+    expect(onChange).toHaveBeenCalledWith("local");
   });
 });

--- a/src/components/wizard/AIProviderStep.tsx
+++ b/src/components/wizard/AIProviderStep.tsx
@@ -16,8 +16,6 @@ export function AIProviderStep() {
   const {
     aiProvider,
     setAiProvider,
-    ollamaModel,
-    setOllamaModel,
     visualSettings,
     setVisualSettings,
     classDetails,
@@ -29,15 +27,12 @@ export function AIProviderStep() {
   const { credits } = useAuth();
   const [purchaseDialogOpen, setPurchaseDialogOpen] = useState(false);
 
-  // Disable next if Local AI is selected but no model is chosen
-  const localAiReady = aiProvider !== "local" || (aiProvider === "local" && ollamaModel);
-
   // Check if user has enough credits for Premium AI
   const hasEnoughCredits = credits && credits.balance >= MINIMUM_CREDITS;
   const showInsufficientCredits = aiProvider === "premium" && !hasEnoughCredits;
 
-  // Can proceed if: Premium AI with enough credits, or Local AI with model selected
-  const canProceed = localAiReady && (aiProvider === "local" || hasEnoughCredits);
+  // Can proceed if: Premium AI with enough credits, or Local AI (backend-managed model)
+  const canProceed = aiProvider === "local" || hasEnoughCredits;
 
   // Check if there are design inspirations selected (images, PDFs, URLs)
   const hasDesignInspiration = selectedInspiration.some(
@@ -62,8 +57,6 @@ export function AIProviderStep() {
         <ProviderSelector
           value={aiProvider}
           onChange={setAiProvider}
-          ollamaModel={ollamaModel}
-          onOllamaModelChange={setOllamaModel}
         />
       </div>
 

--- a/src/components/wizard/GenerationStep.tsx
+++ b/src/components/wizard/GenerationStep.tsx
@@ -33,7 +33,6 @@ export function GenerationStep() {
     selectedInspiration,
     outputPath,
     aiProvider,
-    ollamaModel,
     regeneratingProjectId,
     targetProjectId,
     generationMode,
@@ -131,7 +130,7 @@ export function GenerationStep() {
     }
 
     console.log("[GenerationStep] Starting generation...");
-    console.log(`[GenerationStep] AI Provider: ${aiProvider}, Model: ${ollamaModel || "default"}`);
+    console.log(`[GenerationStep] AI Provider: ${aiProvider}`);
     console.log(`[GenerationStep] Selected inspiration items: ${selectedInspiration.length}`);
 
     setGenerationState({
@@ -230,7 +229,6 @@ export function GenerationStep() {
           },
           inspiration: selectedInspiration,
           aiProvider,
-          aiModel: ollamaModel || undefined,
           prePolished: usePolishedPrompt && polishedPrompt !== null,
           // Premium pipeline parameters
           generationMode: isPremium ? generationMode : "standard",

--- a/src/components/wizard/ProviderSelector.tsx
+++ b/src/components/wizard/ProviderSelector.tsx
@@ -1,25 +1,11 @@
-import { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { cn } from "@/lib/utils";
-import {
-  checkOllamaStatus,
-  type OllamaStatus,
-} from "@/services/tauri-bridge";
 import type { AiProvider } from "@/stores/settingsStore";
 
 interface ProviderSelectorProps {
   value: AiProvider;
   onChange: (provider: AiProvider) => void;
-  ollamaModel: string | null;
-  onOllamaModelChange: (model: string | null) => void;
 }
 
 interface ProviderOption {
@@ -50,50 +36,9 @@ const providers: ProviderOption[] = [
 export function ProviderSelector({
   value,
   onChange,
-  ollamaModel,
-  onOllamaModelChange,
 }: ProviderSelectorProps) {
-  const [ollamaStatus, setOllamaStatus] = useState<OllamaStatus | null>(null);
-  const [checkingOllama, setCheckingOllama] = useState(false);
-
-  useEffect(() => {
-    const checkOllama = async () => {
-      setCheckingOllama(true);
-      try {
-        const status = await checkOllamaStatus();
-        setOllamaStatus(status);
-        // If Local AI is selected but no model is set, and models are available, select the first one
-        if (value === "local" && !ollamaModel && status.models.length > 0) {
-          onOllamaModelChange(status.models[0]);
-        }
-      } catch {
-        setOllamaStatus({
-          installed: false,
-          running: false,
-          version: null,
-          models: [],
-        });
-      } finally {
-        setCheckingOllama(false);
-      }
-    };
-
-    checkOllama();
-  }, [value, ollamaModel, onOllamaModelChange]);
-
-  const isLocalAiAvailable = ollamaStatus?.running && ollamaStatus.models.length > 0;
-
   const handleProviderSelect = (providerId: AiProvider) => {
-    // Allow selecting Local AI even if not available (user might want to set it up)
     onChange(providerId);
-
-    // Clear model if switching away from Local AI
-    if (providerId !== "local") {
-      onOllamaModelChange(null);
-    } else if (ollamaStatus?.models.length) {
-      // Auto-select first model when switching to Local AI
-      onOllamaModelChange(ollamaStatus.models[0]);
-    }
   };
 
   return (
@@ -101,15 +46,13 @@ export function ProviderSelector({
       <div className="grid grid-cols-2 gap-3">
         {providers.map((provider) => {
           const isSelected = value === provider.id;
-          const isLocalUnavailable = provider.id === "local" && !isLocalAiAvailable;
 
           return (
             <Card
               key={provider.id}
               className={cn(
                 "cursor-pointer transition-all hover:border-primary/50",
-                isSelected && "border-primary ring-2 ring-primary/20",
-                isLocalUnavailable && "opacity-60"
+                isSelected && "border-primary ring-2 ring-primary/20"
               )}
               onClick={() => handleProviderSelect(provider.id)}
               role="button"
@@ -135,23 +78,9 @@ export function ProviderSelector({
                 </div>
                 {provider.id === "local" && (
                   <div className="mt-3 pt-3 border-t">
-                    {checkingOllama ? (
-                      <p className="text-xs text-muted-foreground">
-                        Checking local AI status...
-                      </p>
-                    ) : isLocalAiAvailable ? (
-                      <p className="text-xs text-green-600">
-                        Ready ({ollamaStatus?.models.length} model{ollamaStatus?.models.length !== 1 ? 's' : ''} available)
-                      </p>
-                    ) : ollamaStatus?.running ? (
-                      <p className="text-xs text-amber-600">
-                        No models installed
-                      </p>
-                    ) : (
-                      <p className="text-xs text-red-600">
-                        Not running
-                      </p>
-                    )}
+                    <p className="text-xs text-muted-foreground">
+                      Model selection is managed automatically by the backend.
+                    </p>
                   </div>
                 )}
                 {provider.id === "premium" && (
@@ -166,37 +95,6 @@ export function ProviderSelector({
           );
         })}
       </div>
-
-      {value === "local" && ollamaStatus?.running && ollamaStatus.models.length > 0 && (
-        <div className="space-y-1.5">
-          <label className="text-sm font-medium">Local AI Model</label>
-          <Select
-            value={ollamaModel || ""}
-            onValueChange={(val) => onOllamaModelChange(val || null)}
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="Select a model" />
-            </SelectTrigger>
-            <SelectContent>
-              {ollamaStatus.models.map((model) => (
-                <SelectItem key={model} value={model}>
-                  {model}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      )}
-
-      {value === "local" && !isLocalAiAvailable && (
-        <div className="p-3 bg-amber-50 dark:bg-amber-950 rounded-lg">
-          <p className="text-sm text-amber-700 dark:text-amber-300">
-            {!ollamaStatus?.running
-              ? "Local AI is not running. Start it from Settings or choose Premium AI."
-              : "No models installed. Install a model from Settings or choose Premium AI."}
-          </p>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/stores/wizardStore.ts
+++ b/src/stores/wizardStore.ts
@@ -54,7 +54,6 @@ interface WizardState {
 
   // AI Provider state
   aiProvider: AiProvider;
-  ollamaModel: string | null;
 
   // Premium pipeline state
   generationMode: GenerationMode;
@@ -94,7 +93,6 @@ interface WizardState {
   setSelectedInspiration: (items: InspirationItem[]) => void;
   setOutputPath: (path: string) => void;
   setAiProvider: (provider: AiProvider) => void;
-  setOllamaModel: (model: string | null) => void;
   setGenerationMode: (mode: GenerationMode) => void;
   setVisualSettings: (settings: Partial<VisualSettings>) => void;
   setPolishedPrompt: (prompt: string | null) => void;
@@ -132,7 +130,6 @@ export const useWizardStore = create<WizardState>((set, get) => ({
   selectedInspiration: [],
   outputPath: null,
   aiProvider: "local",
-  ollamaModel: null,
   generationMode: "standard",
   visualSettings: { ...DEFAULT_VISUAL_SETTINGS },
   polishedPrompt: null,
@@ -160,7 +157,6 @@ export const useWizardStore = create<WizardState>((set, get) => ({
       selectedInspiration: [],
       outputPath: null,
       aiProvider: defaultProvider,
-      ollamaModel: null,
       generationMode: defaultMode,
       visualSettings: { ...DEFAULT_VISUAL_SETTINGS },
       polishedPrompt: null,
@@ -212,7 +208,6 @@ export const useWizardStore = create<WizardState>((set, get) => ({
       selectedInspiration: inspiration,
       outputPath: project.outputPath || null,
       aiProvider: defaultProvider,
-      ollamaModel: null,
       generationMode: defaultMode,
       visualSettings: { ...DEFAULT_VISUAL_SETTINGS },
       polishedPrompt: null,
@@ -268,7 +263,6 @@ export const useWizardStore = create<WizardState>((set, get) => ({
       selectedInspiration: [],
       outputPath: null,
       aiProvider: defaultProvider,
-      ollamaModel: null,
       generationMode: defaultMode,
       visualSettings: { ...DEFAULT_VISUAL_SETTINGS },
       polishedPrompt: null,
@@ -332,10 +326,6 @@ export const useWizardStore = create<WizardState>((set, get) => ({
     set({ aiProvider: provider, generationMode });
   },
 
-  setOllamaModel: (model) => {
-    set({ ollamaModel: model });
-  },
-
   setGenerationMode: (mode) => {
     set({ generationMode: mode });
   },
@@ -379,7 +369,6 @@ export const useWizardStore = create<WizardState>((set, get) => ({
       selectedInspiration: [],
       outputPath: null,
       aiProvider: defaultProvider,
-      ollamaModel: null,
       generationMode: defaultMode,
       visualSettings: { ...DEFAULT_VISUAL_SETTINGS },
       polishedPrompt: null,


### PR DESCRIPTION
## Summary
- remove wizard `ollamaModel` state and setter from `useWizardStore`
- simplify `ProviderSelector` to provider choice only (no local model dropdown/status checks)
- allow Local AI flow to proceed without model selection gating in `AIProviderStep`
- stop sending `aiModel` from wizard `GenerationStep` payload for local requests
- update wizard component tests and add assertion that local generation requests omit `aiModel`

## Testing
- `npm run test:run -- src/__tests__/components/wizard/ProviderSelector.test.tsx src/__tests__/components/wizard/AIProviderStep.test.tsx src/__tests__/components/wizard/GenerationStep.test.tsx`

Closes #55
