### PR TITLE
[Issue #57] [TASK] End-to-end validation, docs, and release notes for backend-managed free model

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ AI-powered teaching materials generator for K-3 educators. Create worksheets, le
 
 ## Features
 
-- **AI-Powered Generation**: Uses Claude or OpenAI to create grade-appropriate content
+- **AI-Powered Generation**: Premium cloud models (Claude/OpenAI) plus free local generation
 - **Multiple Output Formats**: Worksheets, lesson plans, and answer keys
 - **Print-Ready**: PDF export with professional formatting
 - **Inspiration Support**: Upload PDFs, images, or URLs to guide content generation
@@ -18,7 +18,7 @@ AI-powered teaching materials generator for K-3 educators. Create worksheets, le
 - **State**: Zustand
 - **Backend**: Supabase (Auth, Database, Storage)
 - **Generation API**: Node.js + Express
-- **AI**: Claude API / OpenAI API
+- **AI**: Claude API / OpenAI API / Ollama (local, backend-managed)
 
 ## Getting Started
 
@@ -44,6 +44,22 @@ npm run dev
 # Run Tauri desktop app
 npm run tauri dev
 ```
+
+### Local AI (Free) Policy
+
+Local generation is now backend-managed:
+
+- The backend enforces the local Ollama model policy and ignores client `aiModel` overrides for local requests.
+- Default local model is `llama3.1:8b` with fallback chain: `qwen2.5:7b`, `gemma3:4b`, `llama3.2`.
+- Startup warmup checks Ollama reachability and pulls the selected model automatically when configured.
+- User-facing Ollama setup and model picker controls are removed from the app UI.
+
+Health endpoint (`generation-api`) includes local readiness fields:
+
+- `ollamaReachable`
+- `localModelReady`
+- `activeLocalModel`
+- `warmingUp`
 
 ### Testing
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,1 +1,27 @@
-Bug fixes and improvements.
+# Release Notes
+
+## 2026-02-11 - Backend-Managed Free Local Model Rollout
+
+### Highlights
+- Added backend-managed local model policy for Ollama free generation.
+- Default local model locked to `llama3.1:8b` with fallback chain:
+  1. `qwen2.5:7b`
+  2. `gemma3:4b`
+  3. `llama3.2`
+- Added startup warmup/readiness checks and health visibility fields.
+- Removed user-facing local model/setup controls from the app UI.
+- Hardened frontend-to-tauri surface by removing Ollama control invokes from user-facing paths.
+
+### Behavioral Changes
+- Local/free generation now ignores client-provided `aiModel` values.
+- Prompt polishing for local provider uses the backend-resolved local model path.
+- Wizard local provider flow no longer requires a model dropdown selection.
+
+### Breaking/Compatibility Notes
+- Frontend no longer exposes Local AI setup modal or model picker controls.
+- Tauri invoke surface no longer exposes user-triggerable Ollama control commands (`install/start/stop/pull/list/recommend`).
+- `/health` now includes:
+  - `ollamaReachable`
+  - `localModelReady`
+  - `activeLocalModel`
+  - `warmingUp`

--- a/docs/PROGRESS_TRACKER.md
+++ b/docs/PROGRESS_TRACKER.md
@@ -21,6 +21,21 @@ This document tracks the implementation progress of the TA MVP.
 
 ---
 
+## Recent Milestone (2026-02-11)
+
+- Backend-managed free local model rollout completed (Issues #51-#57).
+- Local model policy locked to:
+  - Primary: `llama3.1:8b`
+  - Fallbacks: `qwen2.5:7b`, `gemma3:4b`, `llama3.2`
+- Backend now owns local model resolution, warmup, and readiness.
+- User-facing Ollama setup/model controls removed from header and wizard.
+- Tauri invoke surface hardened by removing user-triggerable Ollama control commands.
+- Validation snapshot:
+  - Frontend unit tests: 1023/1023 passing
+  - Generation API unit tests: 614/614 passing (with test Supabase env vars)
+
+---
+
 ## Completed Work
 
 ### Phase 1: Project Setup
@@ -149,3 +164,4 @@ This document tracks the implementation progress of the TA MVP.
 | 2024-01-23 | Phases 1-4 marked complete |
 | 2024-01-23 | Phase 5 (Testing) started |
 | 2024-01-23 | Phase 5 (Testing) completed - 178 tests across 12 files |
+| 2026-02-11 | Backend-managed free local model rollout completed (Issues #51-#57, PRs #58-#63) |


### PR DESCRIPTION
## Summary
- update `README.md` with backend-managed local Ollama policy and health readiness fields
- update `QA-TESTING-PLAN.md` with current validation metrics and backend-managed local model regression matrix
- update `RELEASE_NOTES.md` with behavioral and breaking changes from the rollout
- update `docs/PROGRESS_TRACKER.md` with rollout milestone and test summary

## Testing
- `npm run test:run` ✅ (frontend 1023/1023)
- `cd generation-api && npm run test:run` ❌ (`improve.test.ts` requires Supabase env vars)
- `cd generation-api && SUPABASE_URL=http://localhost:54321 SUPABASE_SERVICE_ROLE_KEY=test-service-key npm run test:run` ✅ (API 614/614)

Closes #57
