### PR TITLE
Issue #32: Add runtime Generation API endpoint selection

### DIFF
--- a/src/__tests__/components/layout/Header.test.tsx
+++ b/src/__tests__/components/layout/Header.test.tsx
@@ -29,6 +29,14 @@ vi.mock("@/components/feedback", () => ({
   FeedbackButton: () => <button data-testid="feedback-button">Feedback</button>,
 }));
 
+vi.mock("@/components/settings", () => ({
+  EndpointSettingsDialog: ({
+    open,
+  }: {
+    open: boolean;
+  }) => (open ? <div data-testid="endpoint-settings-dialog">Endpoint Settings</div> : null),
+}));
+
 describe("Header", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -110,6 +118,17 @@ describe("Header", () => {
       render(<Header />);
 
       expect(screen.getByTitle("Sign out")).toBeInTheDocument();
+      expect(screen.getByTitle("Generation API settings")).toBeInTheDocument();
+    });
+  });
+
+  describe("settings", () => {
+    it("opens endpoint settings dialog", async () => {
+      const user = userEvent.setup();
+      render(<Header />);
+
+      await user.click(screen.getByTitle("Generation API settings"));
+      expect(screen.getByTestId("endpoint-settings-dialog")).toBeInTheDocument();
     });
   });
 });

--- a/src/__tests__/components/settings/EndpointSettingsDialog.test.tsx
+++ b/src/__tests__/components/settings/EndpointSettingsDialog.test.tsx
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { EndpointSettingsDialog } from "@/components/settings/EndpointSettingsDialog";
+import { useSettingsStore } from "@/stores/settingsStore";
+
+describe("EndpointSettingsDialog", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({
+      defaultAiProvider: "local",
+      apiEndpointPreset: "local",
+      customApiEndpoint: "",
+      allowPremiumOnLocalDev: false,
+    });
+  });
+
+  it("shows local diagnostics by default", () => {
+    render(<EndpointSettingsDialog open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText("Generation API Endpoint")).toBeInTheDocument();
+    expect(screen.getByTestId("endpoint-diagnostics")).toHaveTextContent(
+      "http://localhost:3001"
+    );
+    expect(screen.getByTestId("endpoint-diagnostics")).toHaveTextContent(
+      "Local/Unhosted"
+    );
+  });
+
+  it("shows custom endpoint input when custom preset is selected", () => {
+    useSettingsStore.setState({
+      apiEndpointPreset: "custom",
+      customApiEndpoint: "https://api.example.com",
+    });
+
+    render(<EndpointSettingsDialog open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByLabelText("Custom API Base URL")).toHaveValue(
+      "https://api.example.com"
+    );
+  });
+});

--- a/src/__tests__/services/api-endpoint-resolver.test.ts
+++ b/src/__tests__/services/api-endpoint-resolver.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getApiBaseUrl, resolveApiUrl } from "@/services/api-endpoint-resolver";
+import { useSettingsStore } from "@/stores/settingsStore";
+
+describe("api-endpoint-resolver", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({
+      defaultAiProvider: "local",
+      apiEndpointPreset: "local",
+      customApiEndpoint: "",
+      allowPremiumOnLocalDev: false,
+    });
+  });
+
+  it("uses the local default endpoint", () => {
+    expect(getApiBaseUrl()).toBe("http://localhost:3001");
+    expect(resolveApiUrl("/health")).toBe("http://localhost:3001/health");
+  });
+
+  it("uses custom endpoint from runtime settings", () => {
+    useSettingsStore.getState().setApiEndpointPreset("custom");
+    useSettingsStore.getState().setCustomApiEndpoint("https://api.school.test");
+
+    expect(getApiBaseUrl()).toBe("https://api.school.test");
+    expect(resolveApiUrl("checkout/packs")).toBe(
+      "https://api.school.test/checkout/packs"
+    );
+  });
+});

--- a/src/__tests__/stores/settingsStore.test.ts
+++ b/src/__tests__/stores/settingsStore.test.ts
@@ -1,18 +1,27 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { useSettingsStore } from "@/stores/settingsStore";
+import { isHostedApiBaseUrl, useSettingsStore } from "@/stores/settingsStore";
 
 describe("settingsStore", () => {
   beforeEach(() => {
     // Reset store state to defaults
     useSettingsStore.setState({
       defaultAiProvider: "local",
+      apiEndpointPreset: "local",
+      customApiEndpoint: "",
+      allowPremiumOnLocalDev: false,
     });
   });
 
   describe("initial state", () => {
     it("defaults to local as the AI provider", () => {
-      const { defaultAiProvider } = useSettingsStore.getState();
+      const { defaultAiProvider, apiEndpointPreset, customApiEndpoint } =
+        useSettingsStore.getState();
       expect(defaultAiProvider).toBe("local");
+      expect(apiEndpointPreset).toBe("local");
+      expect(customApiEndpoint).toBe("");
+      expect(useSettingsStore.getState().getResolvedApiBaseUrl()).toBe(
+        "http://localhost:3001"
+      );
     });
   });
 
@@ -36,6 +45,39 @@ describe("settingsStore", () => {
         useSettingsStore.getState().setDefaultAiProvider(provider);
         expect(useSettingsStore.getState().defaultAiProvider).toBe(provider);
       });
+    });
+  });
+
+  describe("endpoint settings", () => {
+    it("resolves a custom endpoint and normalizes trailing slash", () => {
+      useSettingsStore.getState().setApiEndpointPreset("custom");
+      useSettingsStore
+        .getState()
+        .setCustomApiEndpoint("https://staging.example.com/");
+
+      expect(useSettingsStore.getState().getResolvedApiBaseUrl()).toBe(
+        "https://staging.example.com"
+      );
+    });
+
+    it("falls back to localhost when custom endpoint is empty", () => {
+      useSettingsStore.getState().setApiEndpointPreset("custom");
+      useSettingsStore.getState().setCustomApiEndpoint("   ");
+
+      expect(useSettingsStore.getState().getResolvedApiBaseUrl()).toBe(
+        "http://localhost:3001"
+      );
+    });
+  });
+
+  describe("hosted endpoint detection", () => {
+    it("detects hosted https endpoint", () => {
+      expect(isHostedApiBaseUrl("https://api.example.com")).toBe(true);
+    });
+
+    it("detects local endpoints as unhosted", () => {
+      expect(isHostedApiBaseUrl("http://localhost:3001")).toBe(false);
+      expect(isHostedApiBaseUrl("https://localhost:3001")).toBe(false);
     });
   });
 });

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -7,14 +7,16 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { LogOut, Coins, GraduationCap, User } from "lucide-react";
+import { LogOut, Coins, GraduationCap, User, Settings2 } from "lucide-react";
 import { FeedbackButton } from "@/components/feedback";
 import { PurchaseDialog } from "@/components/purchase";
 import { LearnerSwitcher } from "@/components/learner";
+import { EndpointSettingsDialog } from "@/components/settings";
 
 export function Header() {
   const { profile, credits, signOut } = useAuth();
   const [purchaseDialogOpen, setPurchaseDialogOpen] = useState(false);
+  const [endpointDialogOpen, setEndpointDialogOpen] = useState(false);
 
   // Always show credits badge when available (users may switch between Premium and Local AI)
   const showCredits = credits !== null;
@@ -71,6 +73,17 @@ export function Header() {
           {/* Feedback */}
           <FeedbackButton />
 
+          {/* Runtime endpoint settings */}
+          <Button
+            variant="ghost"
+            size="icon"
+            title="Generation API settings"
+            aria-label="Open generation API settings"
+            onClick={() => setEndpointDialogOpen(true)}
+          >
+            <Settings2 className="h-4 w-4" />
+          </Button>
+
           {/* User info */}
           <div className="flex items-center gap-2 pl-2 border-l">
             <div className="h-8 w-8 rounded-full bg-muted flex items-center justify-center">
@@ -95,6 +108,10 @@ export function Header() {
       <PurchaseDialog
         open={purchaseDialogOpen}
         onOpenChange={setPurchaseDialogOpen}
+      />
+      <EndpointSettingsDialog
+        open={endpointDialogOpen}
+        onOpenChange={setEndpointDialogOpen}
       />
     </header>
   );

--- a/src/components/settings/EndpointSettingsDialog.tsx
+++ b/src/components/settings/EndpointSettingsDialog.tsx
@@ -1,0 +1,107 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import {
+  isHostedApiBaseUrl,
+  type ApiEndpointPreset,
+  useSettingsStore,
+} from "@/stores/settingsStore";
+
+interface EndpointSettingsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const PRESET_LABELS: Record<ApiEndpointPreset, string> = {
+  local: "Local Dev",
+  staging: "Staging",
+  production: "Production",
+  custom: "Custom",
+};
+
+export function EndpointSettingsDialog({
+  open,
+  onOpenChange,
+}: EndpointSettingsDialogProps) {
+  const apiEndpointPreset = useSettingsStore((state) => state.apiEndpointPreset);
+  const customApiEndpoint = useSettingsStore((state) => state.customApiEndpoint);
+  const setApiEndpointPreset = useSettingsStore((state) => state.setApiEndpointPreset);
+  const setCustomApiEndpoint = useSettingsStore((state) => state.setCustomApiEndpoint);
+  const resolvedApiBaseUrl = useSettingsStore((state) => state.getResolvedApiBaseUrl());
+
+  const hosted = isHostedApiBaseUrl(resolvedApiBaseUrl);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[560px]">
+        <DialogHeader>
+          <DialogTitle>Generation API Endpoint</DialogTitle>
+          <DialogDescription>
+            Choose which backend environment this desktop app calls at runtime.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="api-endpoint-preset">Endpoint Preset</Label>
+            <Select
+              value={apiEndpointPreset}
+              onValueChange={(value) => setApiEndpointPreset(value as ApiEndpointPreset)}
+            >
+              <SelectTrigger id="api-endpoint-preset" aria-label="Endpoint preset">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="local">{PRESET_LABELS.local}</SelectItem>
+                <SelectItem value="staging">{PRESET_LABELS.staging}</SelectItem>
+                <SelectItem value="production">{PRESET_LABELS.production}</SelectItem>
+                <SelectItem value="custom">{PRESET_LABELS.custom}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {apiEndpointPreset === "custom" && (
+            <div className="space-y-2">
+              <Label htmlFor="custom-endpoint">Custom API Base URL</Label>
+              <Input
+                id="custom-endpoint"
+                value={customApiEndpoint}
+                onChange={(event) => setCustomApiEndpoint(event.target.value)}
+                placeholder="https://api.example.com"
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck={false}
+              />
+            </div>
+          )}
+
+          <div className="rounded-md border bg-muted/30 p-3 space-y-2" data-testid="endpoint-diagnostics">
+            <p className="text-sm font-medium">Diagnostics</p>
+            <p className="text-xs text-muted-foreground">
+              Active preset: <span className="font-medium text-foreground">{PRESET_LABELS[apiEndpointPreset]}</span>
+            </p>
+            <p className="text-xs text-muted-foreground break-all">
+              Base URL: <span className="font-medium text-foreground">{resolvedApiBaseUrl}</span>
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Endpoint type: <span className="font-medium text-foreground">{hosted ? "Hosted (HTTPS)" : "Local/Unhosted"}</span>
+            </p>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -1,1 +1,2 @@
 export { UpdateDialog } from "./UpdateDialog";
+export { EndpointSettingsDialog } from "./EndpointSettingsDialog";

--- a/src/services/api-endpoint-resolver.ts
+++ b/src/services/api-endpoint-resolver.ts
@@ -1,0 +1,16 @@
+import { useSettingsStore } from "@/stores/settingsStore";
+
+function normalizeEndpoint(endpoint: string): string {
+  if (!endpoint.startsWith("/")) {
+    return `/${endpoint}`;
+  }
+  return endpoint;
+}
+
+export function getApiBaseUrl(): string {
+  return useSettingsStore.getState().getResolvedApiBaseUrl();
+}
+
+export function resolveApiUrl(endpoint: string): string {
+  return `${getApiBaseUrl()}${normalizeEndpoint(endpoint)}`;
+}

--- a/src/services/checkout-api.ts
+++ b/src/services/checkout-api.ts
@@ -1,7 +1,5 @@
 import { GenerationApiError } from "./generation-api";
-
-const API_BASE_URL =
-  import.meta.env.VITE_GENERATION_API_URL || "http://localhost:3001";
+import { resolveApiUrl } from "@/services/api-endpoint-resolver";
 
 export interface CreditPack {
   id: string;
@@ -31,7 +29,7 @@ async function fetchWithAuth(
   options: RequestInit,
   accessToken: string
 ): Promise<Response> {
-  const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+  const response = await fetch(resolveApiUrl(endpoint), {
     ...options,
     headers: {
       "Content-Type": "application/json",

--- a/src/services/feedback-api.ts
+++ b/src/services/feedback-api.ts
@@ -1,8 +1,6 @@
 import { GenerationApiError } from "./generation-api";
 import { TIMEOUTS } from "@/lib/async-utils";
-
-const API_BASE_URL =
-  import.meta.env.VITE_GENERATION_API_URL || "http://localhost:3001";
+import { resolveApiUrl } from "@/services/api-endpoint-resolver";
 
 export interface FeedbackRequest {
   type: "bug" | "feature";
@@ -36,7 +34,7 @@ export async function submitFeedback(
   );
 
   try {
-    const response = await fetch(`${API_BASE_URL}/feedback`, {
+    const response = await fetch(resolveApiUrl("/feedback"), {
       method: "POST",
       signal: controller.signal,
       headers: {

--- a/src/services/generation-api.ts
+++ b/src/services/generation-api.ts
@@ -9,6 +9,7 @@ import type {
   ObjectiveRecommendation,
 } from "@/types";
 import { TIMEOUTS } from "@/lib/async-utils";
+import { resolveApiUrl } from "@/services/api-endpoint-resolver";
 
 export interface PolishContext {
   prompt: string;
@@ -35,8 +36,6 @@ export interface PolishResult {
   skipReason?: PolishSkipReason;
 }
 
-const API_BASE_URL = import.meta.env.VITE_GENERATION_API_URL || "http://localhost:3001";
-
 export class GenerationApiError extends Error {
   constructor(
     message: string,
@@ -58,7 +57,7 @@ async function fetchWithAuth(
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    const response = await fetch(resolveApiUrl(endpoint), {
       ...options,
       signal: controller.signal,
       headers: {
@@ -313,7 +312,7 @@ export async function polishPrompt(
 
 export async function checkHealth(): Promise<boolean> {
   try {
-    const response = await fetch(`${API_BASE_URL}/health`);
+    const response = await fetch(resolveApiUrl("/health"));
     return response.ok;
   } catch {
     return false;

--- a/src/services/improve-api.ts
+++ b/src/services/improve-api.ts
@@ -1,6 +1,5 @@
 import type { ImprovementType, ImprovementResponse } from "@/types";
-
-const API_BASE_URL = import.meta.env.VITE_GENERATION_API_URL || "http://localhost:3001";
+import { resolveApiUrl } from "@/services/api-endpoint-resolver";
 
 export class ImproveApiError extends Error {
   constructor(
@@ -34,7 +33,7 @@ export async function applyImprovement(
   request: ImproveRequest,
   accessToken: string
 ): Promise<ImprovementResponse> {
-  const response = await fetch(`${API_BASE_URL}/improve`, {
+  const response = await fetch(resolveApiUrl("/improve"), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -68,7 +67,7 @@ export async function getImprovementEstimate(
   accessToken: string
 ): Promise<ImproveEstimate> {
   const response = await fetch(
-    `${API_BASE_URL}/improve/estimate?type=${improvementType}`,
+    resolveApiUrl(`/improve/estimate?type=${improvementType}`),
     {
       method: "GET",
       headers: {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -3,13 +3,68 @@ import { persist, type PersistStorage, type StorageValue } from "zustand/middlew
 
 // User-facing provider types (not technical model names)
 export type AiProvider = "premium" | "local";
+export type ApiEndpointPreset = "local" | "staging" | "production" | "custom";
 
 // Legacy provider types for migration
 type LegacyAiProvider = "claude" | "openai" | "ollama";
 
+interface EndpointState {
+  apiEndpointPreset: ApiEndpointPreset;
+  customApiEndpoint: string;
+}
+
+const DEFAULT_LOCAL_API_URL = "http://localhost:3001";
+const DEFAULT_STAGING_API_URL =
+  import.meta.env.VITE_GENERATION_API_URL_STAGING || "";
+const DEFAULT_PRODUCTION_API_URL =
+  import.meta.env.VITE_GENERATION_API_URL_PRODUCTION || "";
+
+function normalizeApiUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+export function resolveApiBaseUrlFromEndpointState(state: EndpointState): string {
+  if (state.apiEndpointPreset === "custom") {
+    const normalizedCustom = normalizeApiUrl(state.customApiEndpoint);
+    return normalizedCustom || DEFAULT_LOCAL_API_URL;
+  }
+
+  if (state.apiEndpointPreset === "staging") {
+    return normalizeApiUrl(DEFAULT_STAGING_API_URL || DEFAULT_LOCAL_API_URL);
+  }
+
+  if (state.apiEndpointPreset === "production") {
+    return normalizeApiUrl(DEFAULT_PRODUCTION_API_URL || DEFAULT_LOCAL_API_URL);
+  }
+
+  return DEFAULT_LOCAL_API_URL;
+}
+
+export function isHostedApiBaseUrl(apiBaseUrl: string): boolean {
+  try {
+    const url = new URL(apiBaseUrl);
+    const host = url.hostname.toLowerCase();
+    const isLocalHost =
+      host === "localhost" ||
+      host === "127.0.0.1" ||
+      host === "::1" ||
+      host.endsWith(".local");
+    return url.protocol === "https:" && !isLocalHost;
+  } catch {
+    return false;
+  }
+}
+
 interface SettingsState {
   defaultAiProvider: AiProvider;
+  apiEndpointPreset: ApiEndpointPreset;
+  customApiEndpoint: string;
+  allowPremiumOnLocalDev: boolean;
   setDefaultAiProvider: (provider: AiProvider) => void;
+  setApiEndpointPreset: (preset: ApiEndpointPreset) => void;
+  setCustomApiEndpoint: (url: string) => void;
+  setAllowPremiumOnLocalDev: (enabled: boolean) => void;
+  getResolvedApiBaseUrl: () => string;
 }
 
 // Custom storage adapter that handles migration from legacy provider values
@@ -29,6 +84,17 @@ const migratingStorage: PersistStorage<SettingsState> = {
           parsed.state.defaultAiProvider = "local";
         }
       }
+
+      // Add newly introduced endpoint settings defaults for old snapshots.
+      if (!parsed.state?.apiEndpointPreset) {
+        parsed.state.apiEndpointPreset = "local";
+      }
+      if (parsed.state?.customApiEndpoint === undefined) {
+        parsed.state.customApiEndpoint = "";
+      }
+      if (parsed.state?.allowPremiumOnLocalDev === undefined) {
+        parsed.state.allowPremiumOnLocalDev = false;
+      }
       return parsed;
     } catch {
       return null;
@@ -44,9 +110,22 @@ const migratingStorage: PersistStorage<SettingsState> = {
 
 export const useSettingsStore = create<SettingsState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       defaultAiProvider: "local", // Default to free option
+      apiEndpointPreset: "local",
+      customApiEndpoint: "",
+      allowPremiumOnLocalDev: false,
       setDefaultAiProvider: (provider) => set({ defaultAiProvider: provider }),
+      setApiEndpointPreset: (preset) => set({ apiEndpointPreset: preset }),
+      setCustomApiEndpoint: (url) => set({ customApiEndpoint: normalizeApiUrl(url) }),
+      setAllowPremiumOnLocalDev: (enabled) => set({ allowPremiumOnLocalDev: enabled }),
+      getResolvedApiBaseUrl: () => {
+        const state = get();
+        return resolveApiBaseUrlFromEndpointState({
+          apiEndpointPreset: state.apiEndpointPreset,
+          customApiEndpoint: state.customApiEndpoint,
+        });
+      },
     }),
     {
       name: "ta-settings",


### PR DESCRIPTION
## Summary
- add persisted runtime API endpoint settings (local/staging/production/custom)
- replace static frontend API URL constants with runtime resolver
- add header-accessible endpoint settings dialog with diagnostics
- add regression tests for endpoint resolution + dialog behavior

## Testing
- npm run test:run -- src/__tests__/stores/settingsStore.test.ts src/__tests__/services/api-endpoint-resolver.test.ts src/__tests__/components/settings/EndpointSettingsDialog.test.tsx src/__tests__/components/layout/Header.test.tsx
- npm run test:run -- src/__tests__/services/generation-api.test.ts src/__tests__/services/checkout-api.test.ts src/__tests__/services/feedback-api.test.ts src/__tests__/services/improve-api.test.ts

Closes #32
