### PR TITLE
Issue #39: Enforce no-keys policy for teacher machines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,5 +89,8 @@ jobs:
       - name: Build frontend
         run: npm run build
 
+      - name: Scan build artifacts for leaked secrets
+        run: npm run scan:artifact-secrets
+
       - name: Check Tauri build
         run: cd src-tauri && cargo check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Run API tests with coverage
         run: cd generation-api && npm run test:coverage
 
+      - name: Build frontend
+        run: npm run build
+
+      - name: Scan build artifacts for leaked secrets
+        run: npm run scan:artifact-secrets
+
       - name: Read release notes
         id: notes
         run: |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ AI-powered teaching materials generator for K-3 educators. Create worksheets, le
 
 ## Features
 
-- **AI-Powered Generation**: Premium cloud models (Claude/OpenAI) plus free local generation
+- **AI-Powered Generation**: Premium cloud generation plus free local generation
 - **Multiple Output Formats**: Worksheets, lesson plans, and answer keys
 - **Print-Ready**: PDF export with professional formatting
 - **Inspiration Support**: Upload PDFs, images, or URLs to guide content generation
@@ -18,7 +18,7 @@ AI-powered teaching materials generator for K-3 educators. Create worksheets, le
 - **State**: Zustand
 - **Backend**: Supabase (Auth, Database, Storage)
 - **Generation API**: Node.js + Express
-- **AI**: Claude API / OpenAI API / Ollama (local, backend-managed)
+- **AI**: OpenAI API / Ollama (local, backend-managed)
 
 ## Getting Started
 
@@ -60,6 +60,15 @@ Health endpoint (`generation-api`) includes local readiness fields:
 - `localModelReady`
 - `activeLocalModel`
 - `warmingUp`
+
+### Premium Safety Policy
+
+- Teacher-facing desktop builds must not contain provider or billing secrets.
+- Premium mode is only enabled when the app targets a hosted HTTPS Generation API endpoint.
+- Local/unhosted endpoints keep Premium disabled by default.
+- A local dev override exists in runtime settings for development only and should remain disabled for teacher distributions.
+- CI and release workflows run `npm run scan:artifact-secrets` against built artifacts to catch leaked key patterns before shipping.
+- Detailed policy/runbook: `docs/security/no-keys-on-teacher-machines.md`.
 
 ### Testing
 

--- a/docs/security/no-keys-on-teacher-machines.md
+++ b/docs/security/no-keys-on-teacher-machines.md
@@ -1,0 +1,25 @@
+# No Keys on Teacher Machines
+
+## Policy
+
+Teacher-facing desktop distributions must not ship with provider, billing, or backend service-role secrets.
+
+## Enforcement
+
+1. Premium AI is enabled only when the runtime Generation API endpoint resolves to a hosted HTTPS URL.
+2. Local/unhosted endpoints disable Premium by default in the wizard.
+3. A `Developer override for Premium` toggle exists for local development only.
+4. CI/release pipelines run `npm run scan:artifact-secrets` to detect leaked key patterns in built artifacts.
+
+## Required Secrets Location
+
+All of the following must stay server-side only:
+
+- `OPENAI_API_KEY`
+- `STRIPE_SECRET_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `PIXABAY_API_KEY`
+
+## Operational Note
+
+For production installs, point desktop clients at the hosted Generation API endpoint via runtime settings (Staging/Production preset or a managed custom HTTPS URL).

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report e2e-report",
-    "bench:ollama": "node scripts/benchmark-ollama-models.cjs"
+    "bench:ollama": "node scripts/benchmark-ollama-models.cjs",
+    "scan:artifact-secrets": "node scripts/scan-artifact-secrets.cjs dist src-tauri/target/release/bundle"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/scan-artifact-secrets.cjs
+++ b/scripts/scan-artifact-secrets.cjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const defaultTargets = ["dist", "src-tauri/target/release/bundle"];
+const targets = process.argv.slice(2);
+const scanTargets = targets.length > 0 ? targets : defaultTargets;
+
+const textExtensions = new Set([
+  ".js",
+  ".cjs",
+  ".mjs",
+  ".ts",
+  ".tsx",
+  ".json",
+  ".html",
+  ".css",
+  ".txt",
+  ".md",
+  ".yml",
+  ".yaml",
+  ".toml",
+]);
+
+const secretPatterns = [
+  { name: "OpenAI key", regex: /sk-[A-Za-z0-9]{20,}/g },
+  { name: "Stripe secret key", regex: /sk_(live|test)_[A-Za-z0-9]{16,}/g },
+  { name: "Stripe restricted key", regex: /rk_(live|test)_[A-Za-z0-9]{16,}/g },
+  { name: "Supabase service role key var", regex: /SUPABASE_SERVICE_ROLE_KEY/g },
+  { name: "OpenAI key var", regex: /OPENAI_API_KEY/g },
+  { name: "Stripe secret var", regex: /STRIPE_SECRET_KEY/g },
+  { name: "Pixabay key var", regex: /PIXABAY_API_KEY/g },
+];
+
+function isTextFile(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  return textExtensions.has(ext);
+}
+
+function walkFiles(dirPath, out = []) {
+  const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(fullPath, out);
+    } else if (entry.isFile()) {
+      out.push(fullPath);
+    }
+  }
+
+  return out;
+}
+
+function findLineNumber(content, index) {
+  return content.slice(0, index).split("\n").length;
+}
+
+const findings = [];
+let scannedFiles = 0;
+
+for (const target of scanTargets) {
+  if (!fs.existsSync(target)) {
+    continue;
+  }
+
+  const files = walkFiles(target).filter(isTextFile);
+  for (const file of files) {
+    scannedFiles += 1;
+    let content;
+    try {
+      content = fs.readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+
+    for (const pattern of secretPatterns) {
+      pattern.regex.lastIndex = 0;
+      const match = pattern.regex.exec(content);
+      if (match) {
+        findings.push({
+          file,
+          pattern: pattern.name,
+          match: match[0],
+          line: findLineNumber(content, match.index),
+        });
+      }
+    }
+  }
+}
+
+if (scannedFiles === 0) {
+  console.log("[scan-artifact-secrets] No target files found to scan.");
+  process.exit(0);
+}
+
+if (findings.length > 0) {
+  console.error("[scan-artifact-secrets] Potential secret leakage detected:");
+  for (const finding of findings) {
+    console.error(
+      `- ${finding.file}:${finding.line} [${finding.pattern}] ${finding.match.slice(0, 80)}`
+    );
+  }
+  process.exit(1);
+}
+
+console.log(`[scan-artifact-secrets] OK - scanned ${scannedFiles} files with no matches.`);

--- a/src/__tests__/components/settings/EndpointSettingsDialog.test.tsx
+++ b/src/__tests__/components/settings/EndpointSettingsDialog.test.tsx
@@ -23,6 +23,9 @@ describe("EndpointSettingsDialog", () => {
     expect(screen.getByTestId("endpoint-diagnostics")).toHaveTextContent(
       "Local/Unhosted"
     );
+    expect(
+      screen.getByLabelText("Allow premium on local endpoint")
+    ).toBeInTheDocument();
   });
 
   it("shows custom endpoint input when custom preset is selected", () => {
@@ -36,5 +39,8 @@ describe("EndpointSettingsDialog", () => {
     expect(screen.getByLabelText("Custom API Base URL")).toHaveValue(
       "https://api.example.com"
     );
+    expect(
+      screen.queryByLabelText("Allow premium on local endpoint")
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/__tests__/components/wizard/AIProviderStep.test.tsx
+++ b/src/__tests__/components/wizard/AIProviderStep.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AIProviderStep } from "@/components/wizard/AIProviderStep";
 import { useWizardStore } from "@/stores/wizardStore";
+import { useSettingsStore } from "@/stores/settingsStore";
 
 let mockCreditsBalance = 50;
 
@@ -48,6 +49,12 @@ describe("AIProviderStep", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCreditsBalance = 50;
+    useSettingsStore.setState({
+      defaultAiProvider: "local",
+      apiEndpointPreset: "local",
+      customApiEndpoint: "",
+      allowPremiumOnLocalDev: true,
+    });
 
     useWizardStore.setState({
       aiProvider: "premium",
@@ -136,5 +143,15 @@ describe("AIProviderStep", () => {
 
     expect(mockPrevStep).toHaveBeenCalledTimes(1);
     expect(mockNextStep).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks Premium AI on local endpoint when override is disabled", () => {
+    useSettingsStore.setState({ allowPremiumOnLocalDev: false });
+    render(<AIProviderStep />);
+
+    expect(
+      screen.getByText(/Premium AI is disabled on this endpoint/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /next/i })).toBeDisabled();
   });
 });

--- a/src/__tests__/components/wizard/ProviderSelector.test.tsx
+++ b/src/__tests__/components/wizard/ProviderSelector.test.tsx
@@ -52,4 +52,23 @@ describe("ProviderSelector", () => {
 
     expect(onChange).toHaveBeenCalledWith("local");
   });
+
+  it("does not call onChange when Premium AI is disabled", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <ProviderSelector
+        {...defaultProps}
+        value="local"
+        onChange={onChange}
+        premiumDisabled
+        premiumDisabledReason="Premium requires hosted endpoint"
+      />
+    );
+    await user.click(screen.getByText("Premium AI").closest("[role='button']")!);
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText(/Premium requires hosted endpoint/i)).toBeInTheDocument();
+  });
 });

--- a/src/components/settings/EndpointSettingsDialog.tsx
+++ b/src/components/settings/EndpointSettingsDialog.tsx
@@ -14,6 +14,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import {
   isHostedApiBaseUrl,
   type ApiEndpointPreset,
@@ -40,6 +41,12 @@ export function EndpointSettingsDialog({
   const customApiEndpoint = useSettingsStore((state) => state.customApiEndpoint);
   const setApiEndpointPreset = useSettingsStore((state) => state.setApiEndpointPreset);
   const setCustomApiEndpoint = useSettingsStore((state) => state.setCustomApiEndpoint);
+  const allowPremiumOnLocalDev = useSettingsStore(
+    (state) => state.allowPremiumOnLocalDev
+  );
+  const setAllowPremiumOnLocalDev = useSettingsStore(
+    (state) => state.setAllowPremiumOnLocalDev
+  );
   const resolvedApiBaseUrl = useSettingsStore((state) => state.getResolvedApiBaseUrl());
 
   const hosted = isHostedApiBaseUrl(resolvedApiBaseUrl);
@@ -100,6 +107,26 @@ export function EndpointSettingsDialog({
               Endpoint type: <span className="font-medium text-foreground">{hosted ? "Hosted (HTTPS)" : "Local/Unhosted"}</span>
             </p>
           </div>
+
+          {!hosted && (
+            <div className="rounded-md border p-3 space-y-2">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-medium">
+                    Developer override for Premium
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Allow Premium on local/unhosted endpoints. Keep this off for teacher-facing builds.
+                  </p>
+                </div>
+                <Switch
+                  checked={allowPremiumOnLocalDev}
+                  onCheckedChange={setAllowPremiumOnLocalDev}
+                  aria-label="Allow premium on local endpoint"
+                />
+              </div>
+            </div>
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/wizard/ProviderSelector.tsx
+++ b/src/components/wizard/ProviderSelector.tsx
@@ -6,6 +6,8 @@ import type { AiProvider } from "@/stores/settingsStore";
 interface ProviderSelectorProps {
   value: AiProvider;
   onChange: (provider: AiProvider) => void;
+  premiumDisabled?: boolean;
+  premiumDisabledReason?: string;
 }
 
 interface ProviderOption {
@@ -36,8 +38,13 @@ const providers: ProviderOption[] = [
 export function ProviderSelector({
   value,
   onChange,
+  premiumDisabled = false,
+  premiumDisabledReason,
 }: ProviderSelectorProps) {
   const handleProviderSelect = (providerId: AiProvider) => {
+    if (providerId === "premium" && premiumDisabled) {
+      return;
+    }
     onChange(providerId);
   };
 
@@ -46,17 +53,22 @@ export function ProviderSelector({
       <div className="grid grid-cols-2 gap-3">
         {providers.map((provider) => {
           const isSelected = value === provider.id;
+          const isDisabled = provider.id === "premium" && premiumDisabled;
 
           return (
             <Card
               key={provider.id}
               className={cn(
-                "cursor-pointer transition-all hover:border-primary/50",
+                "transition-all",
+                isDisabled
+                  ? "cursor-not-allowed opacity-60"
+                  : "cursor-pointer hover:border-primary/50",
                 isSelected && "border-primary ring-2 ring-primary/20"
               )}
               onClick={() => handleProviderSelect(provider.id)}
               role="button"
               aria-pressed={isSelected}
+              aria-disabled={isDisabled}
               aria-label={`Select ${provider.name} as AI provider`}
             >
               <CardContent className="p-4">
@@ -88,6 +100,11 @@ export function ProviderSelector({
                     <p className="text-xs text-muted-foreground">
                       Uses credits (typically 3-6 per worksheet)
                     </p>
+                    {isDisabled && premiumDisabledReason && (
+                      <p className="text-xs text-amber-700 mt-1">
+                        {premiumDisabledReason}
+                      </p>
+                    )}
                   </div>
                 )}
               </CardContent>


### PR DESCRIPTION
## Summary
- gate Premium provider selection to hosted HTTPS API endpoints by default
- add explicit dev-only override toggle for local/unhosted endpoints
- add artifact secret scan script and wire into CI/release workflows
- document no-key policy and hosted-endpoint requirement

## Testing
- npm run test:run -- src/__tests__/components/wizard/ProviderSelector.test.tsx src/__tests__/components/wizard/AIProviderStep.test.tsx src/__tests__/components/settings/EndpointSettingsDialog.test.tsx src/__tests__/stores/settingsStore.test.ts
- npm run scan:artifact-secrets

## Notes
- `npm run build` currently fails due pre-existing unrelated TypeScript test typing issues in the repository.

Closes #39
