### PR TITLE
Issue #43: Separate Stripe staging/prod config and errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Health endpoint (`generation-api`) includes local readiness fields:
 - A local dev override exists in runtime settings for development only and should remain disabled for teacher distributions.
 - CI and release workflows run `npm run scan:artifact-secrets` against built artifacts to catch leaked key patterns before shipping.
 - Detailed policy/runbook: `docs/security/no-keys-on-teacher-machines.md`.
+- Stripe staging/live setup runbook: `docs/ops/stripe-environments.md`.
 
 ### Testing
 

--- a/docs/ops/stripe-environments.md
+++ b/docs/ops/stripe-environments.md
@@ -1,0 +1,45 @@
+# Stripe Environment Separation Runbook
+
+## Goal
+
+Keep staging and production billing isolated so test-mode Stripe objects are never used in production purchases.
+
+## Required Environment Variables
+
+| Variable | Staging | Production |
+|---|---|---|
+| `STRIPE_MODE` | `test` | `live` |
+| `STRIPE_SECRET_KEY` | `sk_test_...` | `sk_live_...` |
+| `STRIPE_WEBHOOK_SECRET` | test webhook secret | live webhook secret |
+| `APP_URL` | staging desktop/web URL | production desktop/web URL |
+
+## Credit Pack Price IDs
+
+Use environment-specific price IDs in `credit_packs.stripe_price_id`:
+
+- Staging rows must reference Stripe **test** price IDs.
+- Production rows must reference Stripe **live** price IDs.
+- Placeholder values (for example `price_*_placeholder`) must not be used in deployed environments.
+
+## Webhook Endpoint Setup
+
+Create one webhook endpoint per environment in Stripe Dashboard:
+
+- Staging endpoint URL: `https://<staging-api-host>/checkout/webhook`
+- Production endpoint URL: `https://<production-api-host>/checkout/webhook`
+
+Recommended events:
+
+- `checkout.session.completed`
+- `checkout.session.expired`
+
+## API Safeguards
+
+`POST /checkout/create-session` now returns explicit codes for easier diagnosis:
+
+- `stripe_not_configured`: missing Stripe secret key
+- `stripe_mode_mismatch`: `STRIPE_MODE` and key prefix do not match
+- `stripe_pack_not_configured`: pack has placeholder/missing price ID
+- `stripe_runtime_error`: Stripe API temporarily unavailable
+
+These are safe for teacher-facing UX and help differentiate configuration issues from transient runtime failures.

--- a/generation-api/.env.example
+++ b/generation-api/.env.example
@@ -16,6 +16,17 @@ PREMIUM_AI_PROVIDER=openai
 # Premium provider (requires API key)
 OPENAI_API_KEY=your-openai-api-key
 
+# Stripe Checkout (required for credit purchases)
+# STRIPE_MODE must match key prefix:
+# - test => sk_test_...
+# - live => sk_live_...
+STRIPE_MODE=test
+STRIPE_SECRET_KEY=sk_test_your_secret_key
+STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret
+
+# Desktop app URL used for Stripe success/cancel redirects
+APP_URL=http://localhost:1420
+
 # Ollama (free local LLM - no API key needed)
 # Install: https://ollama.com/download
 # Then run: ollama pull llama3.2 && ollama serve


### PR DESCRIPTION
## Summary
- add Stripe mode/key validation and explicit checkout error codes
- classify checkout failures as config mismatch vs runtime provider failure
- add staging/production Stripe runbook and update env example

## Testing
- cd generation-api && npm run test:run -- src/__tests__/routes/checkout.test.ts

Closes #43
