### PR TITLE
Issue #50: Fix failed-to-fetch credit packs with actionable errors

### DIFF
--- a/src/__tests__/components/purchase/PurchaseDialog.test.tsx
+++ b/src/__tests__/components/purchase/PurchaseDialog.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "../../utils";
 import { PurchaseDialog } from "@/components/purchase/PurchaseDialog";
+import { GenerationApiError } from "@/services/generation-api";
 
 // Mock the auth hook
 const mockUseAuth = vi.fn();
@@ -238,6 +239,24 @@ describe("PurchaseDialog", () => {
     await waitFor(() => {
       expect(
         screen.getByRole("button", { name: /try again/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows configuration guidance for setup-related errors", async () => {
+    mockGetCreditPacks.mockRejectedValue(
+      new GenerationApiError(
+        "Payments are currently unavailable because Stripe is not configured.",
+        503,
+        { code: "stripe_not_configured" }
+      )
+    );
+
+    render(<PurchaseDialog open={true} onOpenChange={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/billing is not configured for this environment yet/i)
       ).toBeInTheDocument();
     });
   });

--- a/src/__tests__/services/checkout-api.test.ts
+++ b/src/__tests__/services/checkout-api.test.ts
@@ -105,6 +105,24 @@ describe("Checkout API Service", () => {
       });
     });
 
+    it("maps known configuration error codes to actionable messages", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: () =>
+          Promise.resolve({
+            code: "stripe_not_configured",
+            message: "internal message",
+          }),
+      });
+
+      await expect(getCreditPacks(mockAccessToken)).rejects.toMatchObject({
+        statusCode: 503,
+        message:
+          "Payments are currently unavailable because Stripe is not configured.",
+      });
+    });
+
     it("should use correct API base URL from environment", async () => {
       mockFetch.mockResolvedValue({
         ok: true,


### PR DESCRIPTION
## Summary
- classify `/checkout/packs` failures into actionable codes instead of generic 500s
- map checkout pack error codes to teacher-safe frontend messages
- improve purchase dialog guidance and retry behavior for transient failures

## Testing
- cd generation-api && npm run test:run -- src/__tests__/routes/checkout.test.ts
- npm run test:run -- src/__tests__/services/checkout-api.test.ts src/__tests__/components/purchase/PurchaseDialog.test.tsx

Closes #50
