### PR TITLE
Issue #49: Fix cramped Lesson Plan Options layout

### DIFF
--- a/src/__tests__/components/wizard/ClassDetailsStep.test.tsx
+++ b/src/__tests__/components/wizard/ClassDetailsStep.test.tsx
@@ -122,6 +122,16 @@ describe("ClassDetailsStep", () => {
     expect(questionCountInput).toHaveAttribute("max", "20");
   });
 
+  it("uses stacked layout for lesson length and teaching confidence", () => {
+    render(<ClassDetailsStep />);
+
+    const layout = screen.getByTestId("lesson-options-layout");
+    expect(layout).toHaveClass("space-y-4");
+    expect(layout).not.toHaveClass("grid-cols-2");
+    expect(screen.getByTestId("lesson-length-section")).toBeInTheDocument();
+    expect(screen.getByTestId("teaching-confidence-section")).toBeInTheDocument();
+  });
+
   // Note: Detailed Select dropdown interaction tests are better handled in E2E tests
   // due to JSDOM limitations with Radix UI Select component
 });

--- a/src/components/wizard/ClassDetailsStep.tsx
+++ b/src/components/wizard/ClassDetailsStep.tsx
@@ -331,9 +331,9 @@ export function ClassDetailsStep() {
             Lesson Plan Options
           </div>
 
-          {/* Lesson Length */}
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
+          {/* Lesson Length + Teaching Confidence (stacked for readability) */}
+          <div className="space-y-4" data-testid="lesson-options-layout">
+            <div className="space-y-2" data-testid="lesson-length-section">
               <Label className="flex items-center gap-2">
                 <Clock className="h-4 w-4" />
                 Lesson Length
@@ -362,8 +362,11 @@ export function ClassDetailsStep() {
             </div>
 
             {/* Teaching Confidence */}
-            <div className="space-y-2">
+            <div className="space-y-2" data-testid="teaching-confidence-section">
               <Label>Your Teaching Experience</Label>
+              <p className="text-xs text-muted-foreground">
+                Choose the level of scaffolding you want in the lesson plan.
+              </p>
               <Controller
                 name="teachingConfidence"
                 control={control}
@@ -371,7 +374,7 @@ export function ClassDetailsStep() {
                   <RadioGroup
                     onValueChange={field.onChange}
                     value={field.value}
-                    className="space-y-1"
+                    className="space-y-2 rounded-md border bg-muted/20 p-3"
                   >
                     {teachingConfidenceOptions.map((opt) => (
                       <div key={opt.value} className="flex items-start space-x-2">


### PR DESCRIPTION
## Summary
- stack `Lesson Length` and `Your Teaching Experience` vertically in Step 1 lesson options
- give teaching-confidence controls full-width space with helper text and padded container
- add component test to prevent regressions back to cramped two-column layout

## Testing
- npm run test:run -- src/__tests__/components/wizard/ClassDetailsStep.test.tsx

Closes #49
