### PR TITLE
Issue #48: Reduce excessive Step 1 scrolling

### DIFF
--- a/src/__tests__/components/wizard/ClassDetailsStep.test.tsx
+++ b/src/__tests__/components/wizard/ClassDetailsStep.test.tsx
@@ -122,14 +122,25 @@ describe("ClassDetailsStep", () => {
     expect(questionCountInput).toHaveAttribute("max", "20");
   });
 
-  it("uses stacked layout for lesson length and teaching confidence", () => {
+  it("collapses lesson plan options by default", () => {
     render(<ClassDetailsStep />);
+
+    expect(screen.getByTestId("lesson-options-toggle")).toBeInTheDocument();
+    expect(screen.queryByTestId("lesson-options-content")).not.toBeInTheDocument();
+  });
+
+  it("uses stacked layout for lesson length and teaching confidence when expanded", async () => {
+    const user = userEvent.setup();
+    render(<ClassDetailsStep />);
+
+    await user.click(screen.getByTestId("lesson-options-toggle"));
 
     const layout = screen.getByTestId("lesson-options-layout");
     expect(layout).toHaveClass("space-y-4");
     expect(layout).not.toHaveClass("grid-cols-2");
     expect(screen.getByTestId("lesson-length-section")).toBeInTheDocument();
     expect(screen.getByTestId("teaching-confidence-section")).toBeInTheDocument();
+    expect(screen.getByTestId("class-details-footer")).toBeInTheDocument();
   });
 
   // Note: Detailed Select dropdown interaction tests are better handled in E2E tests

--- a/src/__tests__/components/wizard/WizardDialog.test.tsx
+++ b/src/__tests__/components/wizard/WizardDialog.test.tsx
@@ -76,6 +76,16 @@ describe("WizardDialog", () => {
     expect(screen.getByTestId("wizard-steps")).toBeInTheDocument();
   });
 
+  it("uses taller dialog sizing for step visibility", () => {
+    useWizardStore.setState({ isOpen: true });
+
+    render(<WizardDialog />);
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveClass("h-[min(94vh,760px)]");
+    expect(dialog).toHaveClass("w-[95vw]");
+  });
+
   it("calls closeWizard when dialog is closed", async () => {
     const user = userEvent.setup();
     const closeWizard = vi.fn();

--- a/src/components/wizard/WizardDialog.tsx
+++ b/src/components/wizard/WizardDialog.tsx
@@ -13,7 +13,7 @@ export function WizardDialog() {
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && closeWizard()}>
-      <DialogContent className="max-w-3xl max-h-[90vh] min-h-[500px] flex flex-col overflow-hidden">
+      <DialogContent className="max-w-3xl w-[95vw] h-[min(94vh,760px)] min-h-[480px] sm:min-h-[520px] flex flex-col overflow-hidden">
         <DialogHeader className="flex-shrink-0">
           <DialogTitle className="text-lg">
             {currentStep === 6 ? "Generating..." : `Create: ${title}`}


### PR DESCRIPTION
## Summary
- increase wizard dialog usable height on desktop for better Step 1 visibility
- collapse lesson-plan options by default to reduce initial scroll load
- keep Next action consistently reachable with sticky Step 1 footer
- add/adjust component tests for layout and sizing behavior

## Testing
- npm run test:run -- src/__tests__/components/wizard/ClassDetailsStep.test.tsx src/__tests__/components/wizard/WizardDialog.test.tsx

Closes #48
