### PR TITLE
Issue #41: Add K-6 soft-limit warning in required wizard steps

### DIFF
--- a/src/__tests__/components/wizard/AIProviderStep.test.tsx
+++ b/src/__tests__/components/wizard/AIProviderStep.test.tsx
@@ -134,6 +134,28 @@ describe("AIProviderStep", () => {
     expect(screen.getByText(/Design inspiration will be limited/i)).toBeInTheDocument();
   });
 
+  it("shows K-6 soft-limit warning for grade 4-6 regardless of provider", () => {
+    useWizardStore.setState({
+      aiProvider: "local",
+      classDetails: {
+        grade: "5",
+        subject: "Math",
+        format: "worksheet",
+        questionCount: 10,
+        includeVisuals: true,
+        difficulty: "medium",
+        includeAnswerKey: true,
+        lessonLength: 30,
+        studentProfile: [],
+        teachingConfidence: "intermediate",
+      },
+    });
+
+    render(<AIProviderStep />);
+
+    expect(screen.getByText(/K-3 is still the strongest fit/i)).toBeInTheDocument();
+  });
+
   it("calls prevStep and nextStep from buttons", async () => {
     const user = userEvent.setup();
     render(<AIProviderStep />);

--- a/src/__tests__/components/wizard/ClassDetailsStep.test.tsx
+++ b/src/__tests__/components/wizard/ClassDetailsStep.test.tsx
@@ -66,6 +66,27 @@ describe("ClassDetailsStep", () => {
     expect(screen.getByLabelText(/number of questions/i)).toHaveValue(15);
   });
 
+  it("shows K-6 soft-limit warning when grade is 4-6", () => {
+    useWizardStore.setState({
+      classDetails: {
+        grade: "4",
+        subject: "Science",
+        format: "worksheet",
+        questionCount: 15,
+        includeVisuals: true,
+        difficulty: "medium",
+        includeAnswerKey: true,
+        lessonLength: 30,
+        studentProfile: [],
+        teachingConfidence: "intermediate",
+      },
+    });
+
+    render(<ClassDetailsStep />);
+
+    expect(screen.getByText(/K-3 is still the strongest fit/i)).toBeInTheDocument();
+  });
+
   it("allows typing in title field", async () => {
     const user = userEvent.setup();
     render(<ClassDetailsStep />);

--- a/src/__tests__/components/wizard/PromptReviewStep.test.tsx
+++ b/src/__tests__/components/wizard/PromptReviewStep.test.tsx
@@ -78,6 +78,27 @@ describe("PromptReviewStep", () => {
     expect(screen.getByText(/refining your request/i)).toBeInTheDocument();
   });
 
+  it("shows K-6 soft-limit warning for grades 4-6", async () => {
+    useWizardStore.setState({
+      classDetails: {
+        ...defaultClassDetails,
+        grade: "6",
+      },
+    });
+
+    mockPolishPrompt.mockResolvedValue({
+      original: "Original",
+      polished: "Polished",
+      wasPolished: true,
+    });
+
+    render(<PromptReviewStep />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/K-3 is still the strongest fit/i)).toBeInTheDocument();
+    });
+  });
+
   describe("final prompt display", () => {
     it("displays polished prompt in 'What will be sent to AI' section by default", async () => {
       const polishedText = "Create a comprehensive 3rd grade math worksheet focusing on fraction concepts...";

--- a/src/components/wizard/AIProviderStep.tsx
+++ b/src/components/wizard/AIProviderStep.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ChevronLeft, ChevronRight, AlertTriangle, Coins, Info } from "lucide-react";
+import { ChevronLeft, ChevronRight, AlertTriangle, Coins } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -9,6 +9,7 @@ import { ProviderSelector } from "./ProviderSelector";
 import { VisualOptionsPanel } from "./VisualOptionsPanel";
 import { PurchaseDialog } from "@/components/purchase";
 import { isHostedApiBaseUrl, useSettingsStore } from "@/stores/settingsStore";
+import { K6SoftLimitAlert } from "./K6SoftLimitAlert";
 
 // Minimum credits required to start a Premium AI generation
 const MINIMUM_CREDITS = 5;
@@ -54,10 +55,6 @@ export function AIProviderStep() {
 
   // Show warning if Local AI selected with design inspiration
   const showDesignWarning = aiProvider === "local" && hasDesignInspiration;
-
-  // Show soft-limit warning for grades 4-6
-  const gradeNum = classDetails?.grade ? parseInt(classDetails.grade) : 0;
-  const showGradeWarning = aiProvider === "premium" && gradeNum >= 4 && !isNaN(gradeNum);
 
   return (
     <div className="space-y-4">
@@ -143,16 +140,7 @@ export function AIProviderStep() {
         </Alert>
       )}
 
-      {showGradeWarning && (
-        <Alert variant="default" className="border-blue-500 bg-blue-50 dark:bg-blue-950">
-          <Info className="h-4 w-4 text-blue-600" />
-          <AlertDescription className="text-blue-700 dark:text-blue-300">
-            <strong>Best results for K-3.</strong> Grades 4-6 are supported but
-            content quality is optimized for K-3. The premium pipeline includes
-            grade-appropriate vocabulary and pedagogy checks.
-          </AlertDescription>
-        </Alert>
-      )}
+      <K6SoftLimitAlert grade={classDetails?.grade} />
 
       {aiProvider === "premium" && (
         <div className="space-y-3">

--- a/src/components/wizard/ClassDetailsStep.tsx
+++ b/src/components/wizard/ClassDetailsStep.tsx
@@ -19,6 +19,7 @@ import { useWizardStore } from "@/stores/wizardStore";
 import { classDetailsSchema, type ClassDetailsFormData } from "@/lib/validators";
 import type { StudentProfileFlag, TeachingConfidence, LessonLength, ObjectiveRecommendation, Grade } from "@/types";
 import { ObjectiveChooser } from "./ObjectiveChooser";
+import { K6SoftLimitAlert } from "./K6SoftLimitAlert";
 
 // Extended schema with title field (string, not enum)
 const classDetailsWithTitleSchema = classDetailsSchema.extend({
@@ -239,6 +240,8 @@ export function ClassDetailsStep() {
           )}
         </div>
       </div>
+
+      <K6SoftLimitAlert grade={watchedGrade} />
 
       {/* Help me choose - shown for K-3 grades with a selected subject */}
       {hasObjectivePacks && watchedSubject && (

--- a/src/components/wizard/K6SoftLimitAlert.tsx
+++ b/src/components/wizard/K6SoftLimitAlert.tsx
@@ -1,0 +1,31 @@
+import { Info } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+
+export function isK6SoftLimitGrade(grade?: string): boolean {
+  return grade === "4" || grade === "5" || grade === "6";
+}
+
+interface K6SoftLimitAlertProps {
+  grade?: string;
+  className?: string;
+}
+
+export function K6SoftLimitAlert({ grade, className }: K6SoftLimitAlertProps) {
+  if (!isK6SoftLimitGrade(grade)) {
+    return null;
+  }
+
+  return (
+    <Alert
+      variant="default"
+      className={`border-blue-500 bg-blue-50 dark:bg-blue-950 ${className ?? ""}`}
+      data-testid="k6-soft-limit-warning"
+    >
+      <Info className="h-4 w-4 text-blue-600" />
+      <AlertDescription className="text-blue-700 dark:text-blue-300">
+        <strong>K-3 is still the strongest fit.</strong> Grades 4-6 are supported, but
+        results may need extra teacher review and prompt refinement.
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/src/components/wizard/PromptReviewStep.tsx
+++ b/src/components/wizard/PromptReviewStep.tsx
@@ -7,6 +7,7 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { useWizardStore } from "@/stores/wizardStore";
 import { useAuthStore } from "@/stores/authStore";
 import { polishPrompt, type PolishSkipReason } from "@/services/generation-api";
+import { K6SoftLimitAlert } from "./K6SoftLimitAlert";
 
 type PromptChoice = "polished" | "original" | "edited";
 
@@ -162,6 +163,8 @@ export function PromptReviewStep() {
           </p>
         </div>
       </div>
+
+      <K6SoftLimitAlert grade={classDetails?.grade} />
 
       {/* Error state */}
       {polishError && (


### PR DESCRIPTION
## Summary
- add reusable `K6SoftLimitAlert` for grade 4-6 warnings
- render warning in Class Details and Prompt Review steps
- align AI Provider step warning behavior to be provider-agnostic
- add tests covering grade-gated visibility and consistency

## Testing
- npm run test:run -- src/__tests__/components/wizard/AIProviderStep.test.tsx src/__tests__/components/wizard/ClassDetailsStep.test.tsx src/__tests__/components/wizard/PromptReviewStep.test.tsx

Closes #41
