### PR TITLE
Issue #45: Add credits ledger API and UI

### DIFF
--- a/generation-api/src/routes/credits.ts
+++ b/generation-api/src/routes/credits.ts
@@ -1,8 +1,32 @@
 import { Router, type Response } from "express";
 import type { AuthenticatedRequest } from "../middleware/auth.js";
-import { getCredits } from "../services/credits.js";
+import { getCredits, getCreditsLedger } from "../services/credits.js";
 
 const router = Router();
+
+router.get("/ledger", async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    if (!req.userId) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+
+    const rawLimit = typeof req.query.limit === "string" ? Number(req.query.limit) : 20;
+    const limit = Number.isFinite(rawLimit) ? rawLimit : 20;
+    const entries = await getCreditsLedger(req.userId, limit);
+
+    res.json({
+      success: true,
+      entries,
+    });
+  } catch (error) {
+    console.error("Credits ledger fetch error:", error);
+    res.status(500).json({
+      error: "Failed to fetch credits ledger",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+});
 
 router.get("/", async (req: AuthenticatedRequest, res: Response) => {
   try {


### PR DESCRIPTION
## Summary
- add secured `GET /credits/ledger?limit=20` endpoint
- normalize ledger entries to teacher-facing transaction labels (reserve/deduct/refund/purchase/grant)
- add frontend `getCreditsLedger` service call
- render recent credit activity list in Buy Credits dialog with type, timestamp, description, amount
- add route/service/component tests for ledger behavior

## Testing
- cd generation-api && npm run test:run -- src/__tests__/routes/credits.test.ts
- npm run test:run -- src/__tests__/services/checkout-api.test.ts src/__tests__/components/purchase/PurchaseDialog.test.tsx

Closes #45
