### PR TITLE
Issue #44: Add teacher-safe QA failure visibility

### DIFF
--- a/src/services/generation-api.ts
+++ b/src/services/generation-api.ts
@@ -122,7 +122,7 @@ export async function generateTeacherPack(
     throw new GenerationApiError(
       error.error || "Generation failed",
       response.status,
-      error.details
+      error.details || error
     );
   }
 
@@ -218,7 +218,14 @@ async function handleStreamingResponse(
               result = data.result;
             } else if (data.type === "error") {
               console.error("[generation-api] Stream error:", data.message);
-              throw new GenerationApiError(data.message, 500);
+              throw new GenerationApiError(
+                data.message,
+                typeof data.statusCode === "number" ? data.statusCode : 500,
+                {
+                  code: typeof data.code === "string" ? data.code : undefined,
+                  qualityReport: data.qualityReport,
+                }
+              );
             }
           } catch (parseError) {
             if (parseError instanceof GenerationApiError) throw parseError;


### PR DESCRIPTION
## Summary
- add teacher-safe quality failure payloads in generator failures (`qualityReport`, failure code)
- include quality payload in `/generate` SSE error events
- preserve SSE quality details in frontend `GenerationApiError`
- render "What happened" quality panel with retry guidance in GenerationStep
- add route/service/component tests for end-to-end quality-report propagation

## Testing
- cd generation-api && npm run test:run -- src/__tests__/routes/generate.test.ts
- npm run test:run -- src/__tests__/services/generation-api.test.ts src/__tests__/components/wizard/GenerationStep.test.tsx

Closes #44
