### PR TITLE
TA-C01: persist objective metadata on generated artifacts (#35)

### DIFF
--- a/generation-api/src/__tests__/routes/generate.test.ts
+++ b/generation-api/src/__tests__/routes/generate.test.ts
@@ -372,4 +372,38 @@ describe("Generate Route", () => {
       expect.any(Function)
     );
   });
+
+  it("should pass objectiveId through to generator request", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-123", email: "test@example.com" } },
+      error: null,
+    });
+
+    mockGenerateTeacherPack.mockResolvedValue({
+      projectId: "project-123",
+      versionId: "version-456",
+      worksheetHtml: "<html>Worksheet</html>",
+      lessonPlanHtml: "",
+      answerKeyHtml: "",
+      creditsUsed: 5,
+    });
+
+    const response = await request(app)
+      .post("/generate")
+      .set("Authorization", "Bearer valid-token")
+      .send({
+        ...validRequestBody,
+        objectiveId: "math_2_01",
+      });
+
+    expect(response.status).toBe(200);
+    expect(mockGenerateTeacherPack).toHaveBeenCalledWith(
+      expect.objectContaining({
+        objectiveId: "math_2_01",
+      }),
+      expect.anything(),
+      expect.anything(),
+      expect.any(Function)
+    );
+  });
 });

--- a/generation-api/src/routes/generate.ts
+++ b/generation-api/src/routes/generate.ts
@@ -46,6 +46,7 @@ const generateRequestSchema = z.object({
     .optional()
     .default([]),
   inspirationIds: z.array(z.string()).optional(),
+  objectiveId: z.string().optional().nullable(),
   // Accept both user-facing (premium, local) and legacy (claude, openai, ollama) provider values
   aiProvider: z.enum(["premium", "local", "claude", "openai", "ollama"]).optional(),
   aiModel: z.string().optional(),
@@ -153,6 +154,7 @@ router.post("/", async (req: AuthenticatedRequest, res: Response) => {
       subject: data.subject,
       options: data.options,
       inspiration,
+      objectiveId: data.objectiveId || undefined,
       aiProvider,
       prePolished: data.prePolished,
     };

--- a/generation-api/src/types.ts
+++ b/generation-api/src/types.ts
@@ -29,6 +29,7 @@ export interface GenerationRequest {
   options: ProjectOptions;
   inspiration?: InspirationItem[];
   inspirationIds?: string[];
+  objectiveId?: string | null;
   aiProvider?: AIProvider;
   prePolished?: boolean;
 }

--- a/src/__tests__/components/wizard/GenerationStep.test.tsx
+++ b/src/__tests__/components/wizard/GenerationStep.test.tsx
@@ -344,6 +344,21 @@ describe("GenerationStep", () => {
     expect(Object.prototype.hasOwnProperty.call(request, "aiModel")).toBe(false);
   });
 
+  it("includes objectiveId in generation request when objective context exists", async () => {
+    useWizardStore.setState({
+      objectiveId: "math_2_01",
+    });
+
+    render(<GenerationStep />);
+
+    await waitFor(() => {
+      expect(generateTeacherPack).toHaveBeenCalled();
+    }, { timeout: 5000 });
+
+    const request = vi.mocked(generateTeacherPack).mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(request.objectiveId).toBe("math_2_01");
+  });
+
   describe("store synchronization after generation", () => {
     const mockFetchProjectVersion = vi.fn();
 

--- a/src/__tests__/stores/wizardStore.test.ts
+++ b/src/__tests__/stores/wizardStore.test.ts
@@ -25,6 +25,7 @@ describe("wizardStore", () => {
       expect(state.currentStep).toBe(1);
       expect(state.prompt).toBe("");
       expect(state.title).toBe("");
+      expect(state.objectiveId).toBeNull();
       expect(state.classDetails).toBeNull();
       expect(state.selectedInspiration).toEqual([]);
       expect(state.outputPath).toBeNull();
@@ -46,6 +47,7 @@ describe("wizardStore", () => {
       expect(state.currentStep).toBe(1);
       expect(state.prompt).toBe("Create a math worksheet for grade 2");
       expect(state.title).toBe("Create a math worksheet for grade 2");
+      expect(state.objectiveId).toBeNull();
     });
 
     it("should truncate long prompts for title", () => {
@@ -301,6 +303,7 @@ describe("wizardStore", () => {
       expect(state.currentStep).toBe(1);
       expect(state.prompt).toBe("");
       expect(state.title).toBe("");
+      expect(state.objectiveId).toBeNull();
       expect(state.classDetails).toBeNull();
       expect(state.selectedInspiration).toEqual([]);
       expect(state.outputPath).toBeNull();
@@ -392,6 +395,21 @@ describe("wizardStore", () => {
 
       const state = useWizardStore.getState();
       expect(state.regeneratingProjectId).toBe("project-123");
+    });
+
+    it("should restore objectiveId from project options when present", async () => {
+      const projectWithObjective = {
+        ...mockProject,
+        options: {
+          ...mockProject.options,
+          objectiveId: "math_3_01",
+        },
+      };
+
+      const { openWizardForRegeneration } = useWizardStore.getState();
+      await openWizardForRegeneration(projectWithObjective);
+
+      expect(useWizardStore.getState().objectiveId).toBe("math_3_01");
     });
 
     it("REGEN-002: should pre-fill prompt from existing project", async () => {
@@ -576,6 +594,39 @@ describe("wizardStore", () => {
       openWizard("New prompt");
 
       expect(useWizardStore.getState().regeneratingProjectId).toBeNull();
+    });
+  });
+
+  describe("openWizardFromObjective", () => {
+    it("captures objectiveId when launching from learning path objective", () => {
+      const { openWizardFromObjective } = useWizardStore.getState();
+
+      openWizardFromObjective(
+        {
+          id: "math_2_01",
+          text: "Add within 20",
+          difficulty: "standard",
+          estimatedMinutes: 20,
+          unitTitle: "Math - Addition Basics",
+          whyRecommended: "Next objective",
+        },
+        {
+          learnerId: "learner-1",
+          displayName: "Ava",
+          grade: "2",
+          avatarEmoji: "🙂",
+          preferences: {
+            favoriteSubjects: ["Math"],
+            sessionDuration: 30,
+            visualLearner: true,
+          },
+          adultConfidence: "intermediate",
+          createdAt: "2026-02-12T00:00:00Z",
+          updatedAt: "2026-02-12T00:00:00Z",
+        }
+      );
+
+      expect(useWizardStore.getState().objectiveId).toBe("math_2_01");
     });
   });
 });

--- a/src/components/wizard/GenerationStep.tsx
+++ b/src/components/wizard/GenerationStep.tsx
@@ -73,6 +73,7 @@ export function GenerationStep() {
     polishedPrompt,
     usePolishedPrompt,
     title,
+    objectiveId,
     classDetails,
     selectedInspiration,
     outputPath,
@@ -238,6 +239,7 @@ export function GenerationStep() {
             difficulty: classDetails.difficulty,
             format: classDetails.format,
             includeAnswerKey: classDetails.includeAnswerKey,
+            objectiveId: objectiveId || undefined,
           },
           inspiration: persistedInspiration,
           inspirationIds,
@@ -263,6 +265,7 @@ export function GenerationStep() {
           prompt: finalPrompt,
           grade: classDetails.grade,
           subject: classDetails.subject,
+          objectiveId: objectiveId || undefined,
           options: {
             questionCount: classDetails.questionCount,
             includeVisuals: classDetails.includeVisuals,
@@ -309,7 +312,12 @@ export function GenerationStep() {
           grade: classDetails.grade,
           subject: classDetails.subject,
           title,
-          objectiveTags: result.lessonMetadata?.objective ? [result.lessonMetadata.objective] : [],
+          objectiveTags: objectiveId
+            ? [objectiveId]
+            : result.lessonMetadata?.objective
+            ? [result.lessonMetadata.objective]
+            : [],
+          objectiveId: objectiveId || undefined,
           designPackId: selectedPackId || undefined,
           contents: {
             studentPage: result.worksheetHtml,
@@ -333,6 +341,9 @@ export function GenerationStep() {
             if (selectedPackId) {
               await unifiedStore.setDesignPack(targetProjectId, selectedPackId);
             }
+            if (objectiveId) {
+              await unifiedStore.linkObjective(targetProjectId, objectiveId);
+            }
           } else {
             // Create a new Quick Create project
             const unifiedProject = await unifiedStore.createQuickProject(
@@ -342,6 +353,9 @@ export function GenerationStep() {
               selectedPackId || undefined
             );
             unifiedProjectId = unifiedProject.projectId;
+            if (objectiveId) {
+              await unifiedStore.linkObjective(unifiedProjectId, objectiveId);
+            }
           }
 
           // Link saved artifacts to the unified project

--- a/src/services/generation-api.ts
+++ b/src/services/generation-api.ts
@@ -98,6 +98,7 @@ export async function generateTeacherPack(
         prompt: request.prompt,
         grade: request.grade,
         subject: request.subject,
+        objectiveId: request.objectiveId,
         options: request.options,
         inspiration: request.inspiration,
         aiProvider: request.aiProvider || "premium",

--- a/src/services/library-storage.ts
+++ b/src/services/library-storage.ts
@@ -103,6 +103,7 @@ export async function saveArtifact(artifact: LocalArtifact): Promise<void> {
       grade: artifact.grade,
       subject: artifact.subject,
       objectiveTags: artifact.objectiveTags,
+      objectiveId: artifact.objectiveId,
       designPackId: artifact.designPackId,
       filePath: artifact.filePath,
       createdAt: artifact.createdAt,
@@ -220,6 +221,7 @@ export async function saveArtifactsFromGeneration(
   subject: string,
   title: string,
   objectiveTags: string[],
+  objectiveId: string | undefined,
   designPackId: string | undefined,
   contents: {
     studentPage?: string;
@@ -242,6 +244,7 @@ export async function saveArtifactsFromGeneration(
       grade: grade as LocalArtifact["grade"],
       subject,
       objectiveTags,
+      objectiveId,
       designPackId,
       createdAt: now,
     };
@@ -260,6 +263,7 @@ export async function saveArtifactsFromGeneration(
       grade: grade as LocalArtifact["grade"],
       subject,
       objectiveTags,
+      objectiveId,
       designPackId,
       createdAt: now,
     };
@@ -278,6 +282,7 @@ export async function saveArtifactsFromGeneration(
       grade: grade as LocalArtifact["grade"],
       subject,
       objectiveTags,
+      objectiveId,
       designPackId,
       createdAt: now,
     };
@@ -296,6 +301,7 @@ export async function saveArtifactsFromGeneration(
       grade: grade as LocalArtifact["grade"],
       subject,
       objectiveTags,
+      objectiveId,
       designPackId,
       createdAt: now,
     };

--- a/src/stores/artifactStore.ts
+++ b/src/stores/artifactStore.ts
@@ -61,6 +61,7 @@ interface ArtifactState {
     subject: string;
     title: string;
     objectiveTags: string[];
+    objectiveId?: string;
     designPackId?: string;
     contents: {
       studentPage?: string;
@@ -137,7 +138,8 @@ export const useArtifactStore = create<ArtifactState>()((set, get) => ({
     }
     if (filters.objectiveTags.length > 0) {
       filtered = filtered.filter((a) =>
-        a.objectiveTags.some((t) => filters.objectiveTags.includes(t))
+        a.objectiveTags.some((t) => filters.objectiveTags.includes(t)) ||
+        (!!a.objectiveId && filters.objectiveTags.includes(a.objectiveId))
       );
     }
     if (filters.designPackId) {
@@ -306,6 +308,7 @@ export const useArtifactStore = create<ArtifactState>()((set, get) => ({
         params.subject,
         params.title,
         params.objectiveTags,
+        params.objectiveId,
         params.designPackId,
         params.contents
       );

--- a/src/stores/wizardStore.ts
+++ b/src/stores/wizardStore.ts
@@ -48,6 +48,7 @@ interface WizardState {
   currentStep: WizardStep;
   prompt: string;
   title: string;
+  objectiveId: string | null;
   classDetails: ClassDetails | null;
   selectedInspiration: InspirationItem[];
   outputPath: string | null;
@@ -126,6 +127,7 @@ export const useWizardStore = create<WizardState>((set, get) => ({
   currentStep: 1,
   prompt: "",
   title: "",
+  objectiveId: null,
   classDetails: null,
   selectedInspiration: [],
   outputPath: null,
@@ -153,6 +155,7 @@ export const useWizardStore = create<WizardState>((set, get) => ({
       currentStep: 1,
       prompt,
       title,
+      objectiveId: null,
       classDetails: { ...defaultClassDetails },
       selectedInspiration: [],
       outputPath: null,
@@ -173,6 +176,7 @@ export const useWizardStore = create<WizardState>((set, get) => ({
   openWizardForRegeneration: async (project) => {
     // Extract options with defaults
     const options = project.options || {};
+    const objectiveId = typeof options.objectiveId === "string" ? options.objectiveId : null;
 
     // Try to fetch inspiration from junction table first (proper relational approach)
     let inspiration = await useProjectStore.getState().fetchProjectInspiration(project.id);
@@ -192,6 +196,7 @@ export const useWizardStore = create<WizardState>((set, get) => ({
       currentStep: 1,
       prompt: project.prompt,
       title: project.title,
+      objectiveId,
       classDetails: {
         grade: project.grade,
         subject: project.subject,
@@ -248,6 +253,7 @@ export const useWizardStore = create<WizardState>((set, get) => ({
       currentStep: 1,
       prompt,
       title,
+      objectiveId: objective.id,
       classDetails: {
         grade: learner.grade,
         subject: subject,
@@ -365,6 +371,7 @@ export const useWizardStore = create<WizardState>((set, get) => ({
       currentStep: 1,
       prompt: "",
       title: "",
+      objectiveId: null,
       classDetails: null,
       selectedInspiration: [],
       outputPath: null,

--- a/src/types/artifacts.ts
+++ b/src/types/artifacts.ts
@@ -140,6 +140,7 @@ export interface LocalArtifact {
   grade: Grade;
   subject: string;
   objectiveTags: string[];  // Array of objective IDs
+  objectiveId?: string;     // Primary linked objective (when generated from learning path)
   designPackId?: string;    // If generated with a design pack
   filePath?: string;        // Local file path if saved
   createdAt: string;        // ISO string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -89,6 +89,7 @@ export interface GenerationRequest {
   subject: string;
   options: ProjectOptions;
   inspiration: InspirationItem[];
+  objectiveId?: string | null;
   aiProvider?: "premium" | "local" | "claude" | "openai" | "ollama";
   aiModel?: string;
   prePolished?: boolean;


### PR DESCRIPTION
## Summary
- persist `objectiveId` in wizard state from learning-path launch and regeneration context
- pass `objectiveId` through frontend + backend generation request contracts
- persist objective linkage in saved artifacts and include it in library objective filtering

## Testing
- `npm run test:run -- src/__tests__/stores/wizardStore.test.ts src/__tests__/components/wizard/GenerationStep.test.tsx src/__tests__/stores/artifactStore.test.ts`
- `cd generation-api && npm run test:run -- src/__tests__/routes/generate.test.ts`

Closes #35
