### PR TITLE
TA-C02: add back-to-objective affordance in Library preview (#37)

### DIFF
--- a/src/__tests__/components/learning-path/LearningPathView.test.tsx
+++ b/src/__tests__/components/learning-path/LearningPathView.test.tsx
@@ -66,6 +66,31 @@ vi.mock("@/lib/curriculum", () => ({
     { subject: "Math", percentComplete: 33 },
     { subject: "Reading", percentComplete: 50 },
   ],
+  getObjectiveById: vi.fn((objectiveId: string) => {
+    if (objectiveId === "obj-2") {
+      return {
+        subject: "Math",
+        unit: {
+          unitId: "math-2-u1",
+          title: "Numbers and Place Value",
+          grade: "2",
+          sequence: 1,
+          objectives: [],
+        },
+        objective: {
+          id: "obj-2",
+          text: "Understand place value",
+          difficulty: "standard",
+          estimatedMinutes: 20,
+          vocabulary: [],
+          activities: [],
+          prereqs: [],
+          misconceptions: [],
+        },
+      };
+    }
+    return null;
+  }),
 }));
 
 // Mock learner store - now uses profiles + activeLearnerId instead of getActiveProfile
@@ -87,8 +112,20 @@ vi.mock("@/stores/learnerStore", () => ({
 
 // Mock ObjectiveCard to simplify testing
 vi.mock("@/components/learning-path/ObjectiveCard", () => ({
-  ObjectiveCard: ({ objective }: { objective: { text: string } }) => (
-    <div data-testid="objective-card">{objective.text}</div>
+  ObjectiveCard: ({
+    objective,
+    highlighted,
+  }: {
+    objective: { id: string; text: string };
+    highlighted?: boolean;
+  }) => (
+    <div
+      data-testid="objective-card"
+      data-objective-id={objective.id}
+      data-highlighted={highlighted ? "true" : "false"}
+    >
+      {objective.text}
+    </div>
   ),
 }));
 
@@ -234,6 +271,15 @@ describe("LearningPathView", () => {
       // Collapse
       fireEvent.click(screen.getByText("Numbers and Place Value"));
       expect(screen.queryAllByTestId("objective-card")).toHaveLength(0);
+    });
+
+    it("expands and highlights objective when highlightObjectiveId is provided", () => {
+      render(<LearningPathView highlightObjectiveId="obj-2" />);
+      const highlighted = screen.getAllByTestId("objective-card").find((node) =>
+        node.getAttribute("data-objective-id") === "obj-2"
+      );
+      expect(highlighted).toBeTruthy();
+      expect(highlighted?.getAttribute("data-highlighted")).toBe("true");
     });
   });
 

--- a/src/components/layout/MainContent.tsx
+++ b/src/components/layout/MainContent.tsx
@@ -12,11 +12,21 @@ type MainTab = "today" | "learning-path" | "library" | "projects";
 export function MainContent() {
   const [activeTab, setActiveTab] = useState<MainTab>("today");
   const [selectedSubject, setSelectedSubject] = useState<string | undefined>();
+  const [highlightObjectiveId, setHighlightObjectiveId] = useState<string | null>(null);
 
   const currentProject = useProjectStore((state) => state.currentProject);
 
   const handleNavigateToLearningPath = (subject?: string) => {
     setSelectedSubject(subject);
+    setHighlightObjectiveId(null);
+    setActiveTab("learning-path");
+  };
+
+  const handleNavigateToObjective = (objectiveId: string, subject?: string) => {
+    if (subject) {
+      setSelectedSubject(subject);
+    }
+    setHighlightObjectiveId(objectiveId);
     setActiveTab("learning-path");
   };
 
@@ -24,7 +34,16 @@ export function MainContent() {
     <div className="h-full flex flex-col">
       {/* Tab Navigation */}
       <div className="border-b px-4 pt-2">
-        <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as MainTab)}>
+        <Tabs
+          value={activeTab}
+          onValueChange={(v) => {
+            const nextTab = v as MainTab;
+            setActiveTab(nextTab);
+            if (nextTab !== "learning-path") {
+              setHighlightObjectiveId(null);
+            }
+          }}
+        >
           <TabsList className="bg-transparent border-none gap-1">
             <TabsTrigger
               value="today"
@@ -64,9 +83,14 @@ export function MainContent() {
           <TodayView onNavigateToLearningPath={handleNavigateToLearningPath} />
         )}
         {activeTab === "learning-path" && (
-          <LearningPathView initialSubject={selectedSubject} />
+          <LearningPathView
+            initialSubject={selectedSubject}
+            highlightObjectiveId={highlightObjectiveId}
+          />
         )}
-        {activeTab === "library" && <LibraryView />}
+        {activeTab === "library" && (
+          <LibraryView onNavigateToObjective={handleNavigateToObjective} />
+        )}
         {activeTab === "projects" && (
           currentProject ? (
             <ProjectPreview project={currentProject} />

--- a/src/components/learning-path/ObjectiveCard.tsx
+++ b/src/components/learning-path/ObjectiveCard.tsx
@@ -17,6 +17,7 @@ interface ObjectiveCardProps {
   unit: CurriculumUnit;
   subject: string;
   masteryState: MasteryState;
+  highlighted?: boolean;
   compact?: boolean;
   onStartLesson?: () => void;
   onPractice?: () => void;
@@ -28,6 +29,7 @@ export function ObjectiveCard({
   unit,
   subject,
   masteryState,
+  highlighted = false,
   compact = false,
   onStartLesson,
   onPractice,
@@ -120,7 +122,13 @@ export function ObjectiveCard({
   }
 
   return (
-    <Card className="group hover:shadow-md transition-shadow">
+    <Card
+      data-objective-id={objective.id}
+      className={cn(
+        "group hover:shadow-md transition-shadow",
+        highlighted && "border-primary ring-2 ring-primary/40 bg-primary/5"
+      )}
+    >
       <CardContent className="p-4">
         <div className="flex items-start gap-3">
           <MasteryBadge state={masteryState} />


### PR DESCRIPTION
## Summary
- add linked objective action in Library preview when an artifact has `objectiveId`
- route Library objective action into Learning Path tab navigation
- auto-expand and highlight/scroll target objective in Learning Path

## Testing
- `npm run test:run -- src/__tests__/components/library/LibraryView.test.tsx src/__tests__/components/learning-path/LearningPathView.test.tsx src/__tests__/components/layout/MainContent.test.tsx src/__tests__/components/learning-path/ObjectiveCard.test.tsx`

Closes #37
