### PR TITLE
TA-G02: add one-off worksheet flow in Learning Path (#47)

### DIFF
--- a/src/__tests__/components/learning-path/LearningPathView.test.tsx
+++ b/src/__tests__/components/learning-path/LearningPathView.test.tsx
@@ -98,6 +98,7 @@ let mockProfiles: Array<{ learnerId: string; displayName: string; grade: string 
 let mockActiveLearnerId: string | null = null;
 let mockMasteryData: { objectives: Record<string, { state: string }> } | null = null;
 const mockLoadMastery = vi.fn();
+const mockOpenWizardOneOffForLearner = vi.fn();
 
 vi.mock("@/stores/learnerStore", () => ({
   useLearnerStore: vi.fn((selector) =>
@@ -106,6 +107,14 @@ vi.mock("@/stores/learnerStore", () => ({
       activeLearnerId: mockActiveLearnerId,
       masteryData: mockMasteryData,
       loadMastery: mockLoadMastery,
+    })
+  ),
+}));
+
+vi.mock("@/stores/wizardStore", () => ({
+  useWizardStore: vi.fn((selector) =>
+    selector({
+      openWizardOneOffForLearner: mockOpenWizardOneOffForLearner,
     })
   ),
 }));
@@ -135,6 +144,7 @@ describe("LearningPathView", () => {
     mockProfiles = [];
     mockActiveLearnerId = null;
     mockMasteryData = null;
+    mockOpenWizardOneOffForLearner.mockReset();
   });
 
   describe("no active profile", () => {
@@ -210,6 +220,15 @@ describe("LearningPathView", () => {
     it("loads mastery on mount", () => {
       render(<LearningPathView />);
       expect(mockLoadMastery).toHaveBeenCalledWith("learner-1");
+    });
+
+    it("shows create one-off action and calls one-off launcher", () => {
+      render(<LearningPathView />);
+      fireEvent.click(screen.getByRole("button", { name: /create one-off/i }));
+      expect(mockOpenWizardOneOffForLearner).toHaveBeenCalledWith(
+        expect.objectContaining({ learnerId: "learner-1" }),
+        "Math"
+      );
     });
   });
 

--- a/src/__tests__/components/learning-path/TodayView.test.tsx
+++ b/src/__tests__/components/learning-path/TodayView.test.tsx
@@ -7,6 +7,7 @@ const mockLoadProfiles = vi.fn();
 const mockLoadMastery = vi.fn();
 const mockMarkObjectiveStarted = vi.fn();
 const mockOpenWizardFromObjective = vi.fn();
+const mockOpenWizardOneOffForLearner = vi.fn();
 
 let mockProfiles: Array<{
   learnerId: string;
@@ -44,6 +45,7 @@ vi.mock("@/stores/wizardStore", () => ({
   useWizardStore: vi.fn((selector) =>
     selector({
       openWizardFromObjective: mockOpenWizardFromObjective,
+      openWizardOneOffForLearner: mockOpenWizardOneOffForLearner,
     })
   ),
 }));
@@ -190,6 +192,15 @@ describe("TodayView", () => {
       render(<TodayView />);
       expect(screen.getByText("Quick Practice")).toBeInTheDocument();
     });
+
+    it("shows Create one-off button and launches one-off flow with learner context", () => {
+      render(<TodayView />);
+      fireEvent.click(screen.getByText("Create one-off"));
+      expect(mockOpenWizardOneOffForLearner).toHaveBeenCalledWith(
+        expect.objectContaining({ learnerId: "1", grade: "2" }),
+        "Math"
+      );
+    });
   });
 
   describe("all caught up state", () => {
@@ -211,6 +222,11 @@ describe("TodayView", () => {
     it("shows explore learning path button", () => {
       render(<TodayView />);
       expect(screen.getByText("Explore Learning Path")).toBeInTheDocument();
+    });
+
+    it("shows Create one-off button when all caught up", () => {
+      render(<TodayView />);
+      expect(screen.getByText("Create one-off")).toBeInTheDocument();
     });
 
     it("calls onNavigateToLearningPath when explore button clicked", () => {

--- a/src/__tests__/stores/wizardStore.test.ts
+++ b/src/__tests__/stores/wizardStore.test.ts
@@ -699,4 +699,46 @@ describe("wizardStore", () => {
       });
     });
   });
+
+  describe("openWizardOneOffForLearner", () => {
+    const learner = {
+      learnerId: "learner-99",
+      displayName: "Kai",
+      grade: "3" as const,
+      avatarEmoji: "🦊",
+      preferences: {
+        favoriteSubjects: ["Science"],
+        sessionDuration: 45 as const,
+        visualLearner: true,
+      },
+      adultConfidence: "novice" as const,
+      createdAt: "2026-02-12T00:00:00Z",
+      updatedAt: "2026-02-12T00:00:00Z",
+    };
+
+    it("opens one-off worksheet flow with objective cleared", () => {
+      useWizardStore.getState().openWizardOneOffForLearner(learner);
+
+      const state = useWizardStore.getState();
+      expect(state.objectiveId).toBeNull();
+      expect(state.prompt).toContain("one-off worksheet");
+      expect(state.classDetails).toMatchObject({
+        grade: "3",
+        subject: "Science",
+        format: "worksheet",
+        questionCount: 10,
+        includeAnswerKey: true,
+        lessonLength: 45,
+        teachingConfidence: "novice",
+      });
+    });
+
+    it("allows overriding subject while keeping learner defaults", () => {
+      useWizardStore.getState().openWizardOneOffForLearner(learner, "Math");
+      const state = useWizardStore.getState();
+      expect(state.objectiveId).toBeNull();
+      expect(state.classDetails?.subject).toBe("Math");
+      expect(state.classDetails?.grade).toBe("3");
+    });
+  });
 });

--- a/src/components/learning-path/LearningPathView.tsx
+++ b/src/components/learning-path/LearningPathView.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ObjectiveCard } from "./ObjectiveCard";
 import { MasteryBadge } from "./MasteryBadge";
 import { useLearnerStore } from "@/stores/learnerStore";
+import { useWizardStore } from "@/stores/wizardStore";
 import {
   getUnitsForGrade,
   getSubjects,
@@ -22,6 +23,7 @@ import {
   PenTool,
   Microscope,
   Globe,
+  PlusCircle,
 } from "lucide-react";
 
 interface LearningPathViewProps {
@@ -52,6 +54,9 @@ export function LearningPathView({
   const activeLearnerId = useLearnerStore((state) => state.activeLearnerId);
   const masteryData = useLearnerStore((state) => state.masteryData);
   const loadMastery = useLearnerStore((state) => state.loadMastery);
+  const openWizardOneOffForLearner = useWizardStore(
+    (state) => state.openWizardOneOffForLearner
+  );
 
   // Compute derived values with useMemo
   const activeProfile = useMemo(() => {
@@ -191,13 +196,23 @@ export function LearningPathView({
         </div>
 
         {/* Progress summary */}
-        {currentProgress && (
-          <div className="text-right">
-            <div className="text-2xl font-bold text-primary">
-              {currentProgress.percentComplete}%
-            </div>
-            <div className="text-sm text-muted-foreground">
-              {currentProgress.mastered} of {currentProgress.totalObjectives} mastered
+        {currentProgress && activeProfile && (
+          <div className="flex items-center gap-4">
+            <Button
+              variant="outline"
+              onClick={() => openWizardOneOffForLearner(activeProfile, selectedSubject)}
+              className="gap-2"
+            >
+              <PlusCircle className="h-4 w-4" />
+              Create one-off
+            </Button>
+            <div className="text-right">
+              <div className="text-2xl font-bold text-primary">
+                {currentProgress.percentComplete}%
+              </div>
+              <div className="text-sm text-muted-foreground">
+                {currentProgress.mastered} of {currentProgress.totalObjectives} mastered
+              </div>
             </div>
           </div>
         )}

--- a/src/components/learning-path/TodayView.tsx
+++ b/src/components/learning-path/TodayView.tsx
@@ -15,6 +15,7 @@ import {
   Clock,
   UserPlus,
   ArrowRight,
+  PlusCircle,
 } from "lucide-react";
 import { useState } from "react";
 import {
@@ -55,6 +56,9 @@ export function TodayView({ onNavigateToLearningPath }: TodayViewProps) {
 
   const openWizardFromObjective = useWizardStore(
     (state) => state.openWizardFromObjective
+  );
+  const openWizardOneOffForLearner = useWizardStore(
+    (state) => state.openWizardOneOffForLearner
   );
 
   // Load profiles and mastery on mount
@@ -162,6 +166,11 @@ export function TodayView({ onNavigateToLearningPath }: TodayViewProps) {
     );
   };
 
+  const handleCreateOneOff = () => {
+    if (!activeProfile) return;
+    openWizardOneOffForLearner(activeProfile, nextObjective?.subject);
+  };
+
   return (
     <div className="space-y-6 max-w-4xl mx-auto">
       {/* Greeting */}
@@ -215,6 +224,10 @@ export function TodayView({ onNavigateToLearningPath }: TodayViewProps) {
                 <FileText className="h-4 w-4" />
                 Quick Practice
               </Button>
+              <Button variant="secondary" onClick={handleCreateOneOff} className="gap-2">
+                <PlusCircle className="h-4 w-4" />
+                Create one-off
+              </Button>
             </div>
           </CardContent>
         </Card>
@@ -233,6 +246,14 @@ export function TodayView({ onNavigateToLearningPath }: TodayViewProps) {
             >
               Explore Learning Path
               <ArrowRight className="ml-2 h-4 w-4" />
+            </Button>
+            <Button
+              variant="secondary"
+              className="mt-2"
+              onClick={handleCreateOneOff}
+            >
+              <PlusCircle className="mr-2 h-4 w-4" />
+              Create one-off
             </Button>
           </CardContent>
         </Card>

--- a/src/stores/wizardStore.ts
+++ b/src/stores/wizardStore.ts
@@ -126,6 +126,7 @@ interface WizardState {
     learner: LearnerProfile,
     format?: "worksheet" | "lesson_plan" | "both"
   ) => void;
+  openWizardOneOffForLearner: (learner: LearnerProfile, subject?: string) => void;
   closeWizard: () => void;
   setStep: (step: WizardStep) => void;
   nextStep: () => void;
@@ -317,6 +318,50 @@ export const useWizardStore = create<WizardState>((set, get) => ({
         lessonLength,
         studentProfile: [],
         teachingConfidence: learner.adultConfidence,
+      },
+      selectedInspiration: [],
+      outputPath: null,
+      aiProvider: defaultProvider,
+      generationMode: defaultMode,
+      visualSettings: { ...DEFAULT_VISUAL_SETTINGS },
+      polishedPrompt: null,
+      usePolishedPrompt: true,
+      regeneratingProjectId: null,
+      targetProjectId: null,
+      isGenerating: false,
+      generationProgress: 0,
+      generationMessage: "",
+      generationError: null,
+    });
+  },
+
+  openWizardOneOffForLearner: (learner, subject) => {
+    const resolvedSubject =
+      subject || learner.preferences?.favoriteSubjects?.[0] || "Math";
+    const lessonLength = normalizeLessonLength(learner.preferences?.sessionDuration || 30);
+    const prompt = `Create a one-off worksheet for Grade ${learner.grade} ${resolvedSubject}.`;
+    const title = `One-off ${resolvedSubject} worksheet`;
+
+    const defaultProvider = useSettingsStore.getState().defaultAiProvider;
+    const defaultMode = resolveGenerationMode(defaultProvider, "worksheet");
+
+    set({
+      isOpen: true,
+      currentStep: 1,
+      prompt,
+      title,
+      objectiveId: null,
+      classDetails: {
+        grade: learner.grade,
+        subject: resolvedSubject,
+        format: "worksheet",
+        questionCount: 10,
+        includeVisuals: true,
+        difficulty: "medium",
+        includeAnswerKey: true,
+        lessonLength,
+        studentProfile: [],
+        teachingConfidence: learner.adultConfidence || "intermediate",
       },
       selectedInspiration: [],
       outputPath: null,


### PR DESCRIPTION
## Summary
- add first-class `Create one-off` actions in Learning Path surfaces
- add wizard-store one-off entrypoint that preserves learner context and enforces `objectiveId = null`
- add regression coverage for one-off launch behavior and objective-bound flow safety

## Testing
- `npm run test:run -- src/__tests__/stores/wizardStore.test.ts src/__tests__/components/learning-path/TodayView.test.tsx src/__tests__/components/learning-path/LearningPathView.test.tsx src/__tests__/components/layout/MainContent.test.tsx`

Closes #47
