### PR TITLE
TA-B03: dedupe inspiration helper and drag/drop logic (#36)

### DIFF
--- a/src/__tests__/hooks/useInspirationDrop.test.tsx
+++ b/src/__tests__/hooks/useInspirationDrop.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useInspirationDrop } from "@/hooks/useInspirationDrop";
+import { readFileAsBase64 } from "@/lib/file-encoding";
+
+vi.mock("@/lib/file-encoding", () => ({
+  readFileAsBase64: vi.fn(),
+}));
+
+function DropHarness({
+  onAddItem,
+  onItemsAdded,
+}: {
+  onAddItem: (item: unknown) => Promise<unknown> | unknown;
+  onItemsAdded?: (items: unknown[]) => Promise<void> | void;
+}) {
+  const { isDragging, handleDrop, handleDragOver, handleDragLeave } = useInspirationDrop({
+    onAddItem,
+    onItemsAdded,
+  });
+
+  return (
+    <div
+      data-testid="drop-zone"
+      data-dragging={isDragging ? "true" : "false"}
+      onDrop={handleDrop}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+    />
+  );
+}
+
+describe("useInspirationDrop", () => {
+  it("processes dropped URL text and reports added items", async () => {
+    const onAddItem = vi.fn(async (item) => ({ id: "new-item", ...(item as Record<string, unknown>) }));
+    const onItemsAdded = vi.fn();
+
+    render(<DropHarness onAddItem={onAddItem} onItemsAdded={onItemsAdded} />);
+    const zone = screen.getByTestId("drop-zone");
+
+    fireEvent.drop(zone, {
+      dataTransfer: {
+        files: [],
+        getData: (type: string) => (type === "text/plain" ? "https://example.com/resource" : ""),
+      },
+    });
+
+    await waitFor(() => {
+      expect(onAddItem).toHaveBeenCalledWith({
+        type: "url",
+        title: "example.com",
+        sourceUrl: "https://example.com/resource",
+      });
+      expect(onItemsAdded).toHaveBeenCalledWith([
+        expect.objectContaining({ id: "new-item", type: "url" }),
+      ]);
+    });
+  });
+
+  it("processes dropped PDFs and tracks drag state", async () => {
+    vi.mocked(readFileAsBase64).mockResolvedValue("pdf-base64");
+    const onAddItem = vi.fn(async (item) => ({ id: "pdf-item", ...(item as Record<string, unknown>) }));
+
+    render(<DropHarness onAddItem={onAddItem} />);
+    const zone = screen.getByTestId("drop-zone");
+    const pdf = new File(["%PDF"], "sample.pdf", { type: "application/pdf" });
+
+    fireEvent.dragOver(zone, {
+      dataTransfer: { files: [pdf], getData: () => "" },
+    });
+    expect(zone.getAttribute("data-dragging")).toBe("true");
+
+    fireEvent.dragLeave(zone, {
+      dataTransfer: { files: [pdf], getData: () => "" },
+    });
+    expect(zone.getAttribute("data-dragging")).toBe("false");
+
+    fireEvent.drop(zone, {
+      dataTransfer: {
+        files: [pdf],
+        getData: () => "",
+      },
+    });
+
+    await waitFor(() => {
+      expect(onAddItem).toHaveBeenCalledWith({
+        type: "pdf",
+        title: "sample.pdf",
+        content: "pdf-base64",
+      });
+    });
+  });
+});

--- a/src/__tests__/lib/inspiration-icons.test.ts
+++ b/src/__tests__/lib/inspiration-icons.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { FileText, Image, Link } from "lucide-react";
+import { getInspirationIcon } from "@/lib/inspiration-icons";
+
+describe("getInspirationIcon", () => {
+  it("returns Link icon for url items", () => {
+    expect(getInspirationIcon("url")).toBe(Link);
+  });
+
+  it("returns Image icon for image items", () => {
+    expect(getInspirationIcon("image")).toBe(Image);
+  });
+
+  it("returns FileText icon for pdf and unknown types", () => {
+    expect(getInspirationIcon("pdf")).toBe(FileText);
+    expect(getInspirationIcon("text")).toBe(FileText);
+    expect(getInspirationIcon("unknown")).toBe(FileText);
+  });
+});

--- a/src/hooks/useInspirationDrop.ts
+++ b/src/hooks/useInspirationDrop.ts
@@ -1,0 +1,103 @@
+import { useCallback, useState } from "react";
+import { readFileAsBase64 } from "@/lib/file-encoding";
+
+export interface DropInspirationInput {
+  type: "url" | "pdf" | "image";
+  title: string;
+  sourceUrl?: string;
+  content?: string;
+  storagePath?: string;
+}
+
+interface UseInspirationDropOptions<TItem> {
+  onAddItem: (item: DropInspirationInput) => Promise<TItem> | TItem;
+  onItemsAdded?: (items: TItem[]) => Promise<void> | void;
+  onError?: (error: unknown, context?: string) => void;
+}
+
+export function useInspirationDrop<TItem>({
+  onAddItem,
+  onItemsAdded,
+  onError,
+}: UseInspirationDropOptions<TItem>) {
+  const [isDragging, setIsDragging] = useState(false);
+
+  const handleDrop = useCallback(
+    async (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDragging(false);
+
+      const files = Array.from(e.dataTransfer.files || []);
+      const text = e.dataTransfer.getData("text/plain");
+      const url = e.dataTransfer.getData("text/uri-list");
+      const addedItems: TItem[] = [];
+
+      // Handle URL drops before file parsing.
+      const droppedUrl = url || text;
+      if (droppedUrl && droppedUrl.startsWith("http")) {
+        try {
+          const parsedUrl = new URL(droppedUrl);
+          const newItem = await onAddItem({
+            type: "url",
+            title: parsedUrl.hostname,
+            sourceUrl: droppedUrl,
+          });
+          addedItems.push(newItem);
+        } catch (error) {
+          onError?.(error, droppedUrl);
+        }
+      } else {
+        for (const file of files) {
+          try {
+            if (file.type === "application/pdf") {
+              const base64Content = await readFileAsBase64(file);
+              const newItem = await onAddItem({
+                type: "pdf",
+                title: file.name,
+                content: base64Content,
+              });
+              addedItems.push(newItem);
+            } else if (file.type.startsWith("image/")) {
+              const base64Content = await readFileAsBase64(file);
+              const mediaType = file.type as "image/jpeg" | "image/png" | "image/gif" | "image/webp";
+              const newItem = await onAddItem({
+                type: "image",
+                title: file.name,
+                content: base64Content,
+                storagePath: mediaType,
+              });
+              addedItems.push(newItem);
+            }
+          } catch (error) {
+            onError?.(error, file.name);
+          }
+        }
+      }
+
+      if (addedItems.length > 0) {
+        await onItemsAdded?.(addedItems);
+      }
+    },
+    [onAddItem, onItemsAdded, onError]
+  );
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+  }, []);
+
+  return {
+    isDragging,
+    handleDrop,
+    handleDragOver,
+    handleDragLeave,
+  };
+}

--- a/src/lib/inspiration-icons.ts
+++ b/src/lib/inspiration-icons.ts
@@ -1,0 +1,15 @@
+import { FileText, Image, Link } from "lucide-react";
+
+export type InspirationKind = "url" | "pdf" | "image" | "text" | string;
+
+export function getInspirationIcon(type: InspirationKind) {
+  switch (type) {
+    case "url":
+      return Link;
+    case "image":
+      return Image;
+    case "pdf":
+    default:
+      return FileText;
+  }
+}


### PR DESCRIPTION
## Summary
- extract shared inspiration icon helper
- extract reusable inspiration drop hook for URL/PDF/image ingestion
- adopt shared logic in wizard inspiration step, sidebar inspiration panel, and design packs panel

## Testing
- `npm run test:run -- src/__tests__/hooks/useInspirationDrop.test.tsx src/__tests__/lib/inspiration-icons.test.ts src/__tests__/components/wizard/InspirationStep.test.tsx src/__tests__/components/panels/InspirationPanel.test.tsx src/__tests__/components/design-packs/DesignPacksPanel.test.tsx`

Closes #36
