### PR TITLE
TA-B01: wire design packs into inspiration generation path (#33)

### DIFF
--- a/generation-api/src/types.ts
+++ b/generation-api/src/types.ts
@@ -6,6 +6,7 @@ export type {
   LessonLength,
   ProjectOptions,
   InspirationItem,
+  DesignPackContext,
   LessonMetadata,
   GenerationProgress,
   GenerationResult,
@@ -13,7 +14,7 @@ export type {
 } from "@shared/types";
 
 // Import shared types used by local interfaces below
-import type { Grade, ProjectOptions, InspirationItem, ImageStats } from "@shared/types";
+import type { Grade, ProjectOptions, InspirationItem, DesignPackContext, ImageStats } from "@shared/types";
 
 // User-facing provider types + legacy internal types for backward compatibility
 export type AIProvider = "premium" | "local" | "claude" | "openai" | "ollama";
@@ -30,6 +31,7 @@ export interface GenerationRequest {
   inspiration?: InspirationItem[];
   inspirationIds?: string[];
   objectiveId?: string | null;
+  designPackContext?: DesignPackContext;
   aiProvider?: AIProvider;
   prePolished?: boolean;
 }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -91,6 +91,11 @@ export interface InspirationItem {
   createdAt?: Date;
 }
 
+export interface DesignPackContext {
+  packId: string;
+  items: InspirationItem[];
+}
+
 // ============================================
 // Image Stats
 // ============================================

--- a/src/__tests__/components/wizard/PromptReviewStep.test.tsx
+++ b/src/__tests__/components/wizard/PromptReviewStep.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { PromptReviewStep } from "@/components/wizard/PromptReviewStep";
 import { useWizardStore } from "@/stores/wizardStore";
 import { useAuthStore } from "@/stores/authStore";
+import { useDesignPackStore } from "@/stores/designPackStore";
 
 // Mock the polishPrompt API function
 const mockPolishPrompt = vi.fn();
@@ -65,6 +66,11 @@ describe("PromptReviewStep", () => {
         expires_at: Date.now() + 3600000,
       },
     });
+
+    useDesignPackStore.setState({
+      packs: [],
+      selectedPackId: null,
+    });
   });
 
   it("shows loading state while polishing", async () => {
@@ -96,6 +102,41 @@ describe("PromptReviewStep", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/K-3 is still the strongest fit/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows selected design-pack context in review", async () => {
+    useDesignPackStore.setState({
+      selectedPackId: "pack-1",
+      packs: [
+        {
+          packId: "pack-1",
+          name: "Spring Theme Pack",
+          items: [
+            {
+              itemId: "item-1",
+              type: "url",
+              title: "Classroom Theme",
+              sourceUrl: "https://example.com/theme",
+            },
+          ],
+          createdAt: "2026-02-12T00:00:00Z",
+          updatedAt: "2026-02-12T00:00:00Z",
+        },
+      ],
+    });
+
+    mockPolishPrompt.mockResolvedValue({
+      original: "Original",
+      polished: "Polished",
+      wasPolished: true,
+    });
+
+    render(<PromptReviewStep />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("design-pack-context")).toBeInTheDocument();
+      expect(screen.getByText(/Spring Theme Pack/)).toBeInTheDocument();
     });
   });
 

--- a/src/__tests__/lib/inspiration-merge.test.ts
+++ b/src/__tests__/lib/inspiration-merge.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { mapDesignPackItemsToInspiration, mergeInspirationItems } from "@/lib/inspiration-merge";
+
+describe("inspiration merge utilities", () => {
+  it("maps design pack items into inspiration-compatible items", () => {
+    const mapped = mapDesignPackItemsToInspiration("pack-1", [
+      {
+        itemId: "item-1",
+        type: "url",
+        title: "Example",
+        sourceUrl: "https://example.com",
+      },
+    ]);
+
+    expect(mapped).toEqual([
+      expect.objectContaining({
+        id: "pack:pack-1:item-1",
+        type: "url",
+        title: "Example",
+        sourceUrl: "https://example.com",
+      }),
+    ]);
+  });
+
+  it("merges ad-hoc and design-pack inspiration deterministically with de-duplication", () => {
+    const adHoc = [
+      {
+        id: "adhoc-1",
+        type: "url" as const,
+        title: "Example",
+        sourceUrl: "https://example.com",
+      },
+    ];
+    const packItems = [
+      {
+        id: "pack-dup",
+        type: "url" as const,
+        title: "Example",
+        sourceUrl: "https://example.com",
+      },
+      {
+        id: "pack-2",
+        type: "pdf" as const,
+        title: "Unit Notes",
+        content: "base64-pdf",
+      },
+    ];
+
+    const merged = mergeInspirationItems(adHoc, packItems);
+    expect(merged).toHaveLength(2);
+    expect(merged[0].id).toBe("adhoc-1");
+    expect(merged[1].id).toBe("pack-2");
+  });
+});

--- a/src/__tests__/services/generation-api.test.ts
+++ b/src/__tests__/services/generation-api.test.ts
@@ -95,6 +95,58 @@ describe("Generation API Service", () => {
         generateTeacherPack(mockRequest, "test-token")
       ).rejects.toThrow(GenerationApiError);
     });
+
+    it("should include designPackContext when provided", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        headers: {
+          get: () => "application/json",
+        },
+        json: () =>
+          Promise.resolve({
+            result: {
+              projectId: "project-123",
+              versionId: "version-456",
+              worksheetHtml: "<p>Worksheet</p>",
+              lessonPlanHtml: "",
+              answerKeyHtml: "",
+              creditsUsed: 5,
+            },
+          }),
+      });
+
+      await generateTeacherPack(
+        {
+          ...mockRequest,
+          designPackContext: {
+            packId: "pack-1",
+            items: [
+              {
+                id: "pack:pack-1:item-1",
+                type: "url",
+                title: "Pack Link",
+                sourceUrl: "https://example.com/pack-link",
+              },
+            ],
+          },
+        },
+        "test-token"
+      );
+
+      const fetchArgs = mockFetch.mock.calls[0]?.[1] as { body?: string };
+      const body = fetchArgs?.body ? JSON.parse(fetchArgs.body) : {};
+      expect(body.designPackContext).toEqual({
+        packId: "pack-1",
+        items: [
+          {
+            id: "pack:pack-1:item-1",
+            type: "url",
+            title: "Pack Link",
+            sourceUrl: "https://example.com/pack-link",
+          },
+        ],
+      });
+    });
   });
 
   describe("getCredits", () => {

--- a/src/components/wizard/PromptReviewStep.tsx
+++ b/src/components/wizard/PromptReviewStep.tsx
@@ -5,6 +5,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { useWizardStore } from "@/stores/wizardStore";
+import { useDesignPackStore } from "@/stores/designPackStore";
 import { useAuthStore } from "@/stores/authStore";
 import { polishPrompt, type PolishSkipReason } from "@/services/generation-api";
 import { K6SoftLimitAlert } from "./K6SoftLimitAlert";
@@ -30,7 +31,13 @@ export function PromptReviewStep() {
     nextStep,
     prevStep,
   } = useWizardStore();
+  const selectedPack = useDesignPackStore((state) => state.getSelectedPack());
   const { session } = useAuthStore();
+
+  const designPackTitles = selectedPack?.items.map((item) => item.title || item.itemId) || [];
+  const inspirationTitles = Array.from(
+    new Set([...selectedInspiration.map((i) => i.title || i.id), ...designPackTitles])
+  );
 
   const [isPolishing, setIsPolishing] = useState(false);
   const [polishError, setPolishError] = useState<string | null>(null);
@@ -65,7 +72,7 @@ export function PromptReviewStep() {
           questionCount: classDetails.questionCount,
           difficulty: classDetails.difficulty,
           includeVisuals: classDetails.includeVisuals,
-          inspirationTitles: selectedInspiration.map((i) => i.title || i.id),
+          inspirationTitles,
         },
         session.access_token
       );
@@ -165,6 +172,19 @@ export function PromptReviewStep() {
       </div>
 
       <K6SoftLimitAlert grade={classDetails?.grade} />
+
+      {selectedPack && (
+        <div className="p-3 bg-muted/40 rounded-lg border" data-testid="design-pack-context">
+          <p className="text-sm font-medium">
+            Design Pack Context: {selectedPack.name}
+          </p>
+          <p className="text-xs text-muted-foreground mt-1">
+            {selectedPack.items.length} item
+            {selectedPack.items.length !== 1 ? "s" : ""} will be merged with ad-hoc inspiration
+            for generation.
+          </p>
+        </div>
+      )}
 
       {/* Error state */}
       {polishError && (

--- a/src/lib/inspiration-merge.ts
+++ b/src/lib/inspiration-merge.ts
@@ -1,0 +1,39 @@
+import type { DesignPackItem, InspirationItem } from "@/types";
+
+function createInspirationMergeKey(item: InspirationItem): string {
+  return [
+    item.type,
+    item.sourceUrl || "",
+    item.title || "",
+    item.content || "",
+    item.storagePath || "",
+  ].join("|");
+}
+
+export function mapDesignPackItemsToInspiration(
+  packId: string,
+  items: DesignPackItem[]
+): InspirationItem[] {
+  return items.map((item) => ({
+    id: `pack:${packId}:${item.itemId}`,
+    type: item.type,
+    title: item.title,
+    sourceUrl: item.sourceUrl,
+    content: item.content,
+    storagePath: item.storagePath,
+  }));
+}
+
+export function mergeInspirationItems(
+  adHocItems: InspirationItem[],
+  designPackItems: InspirationItem[]
+): InspirationItem[] {
+  const merged = new Map<string, InspirationItem>();
+  for (const item of [...adHocItems, ...designPackItems]) {
+    const key = createInspirationMergeKey(item);
+    if (!merged.has(key)) {
+      merged.set(key, item);
+    }
+  }
+  return Array.from(merged.values());
+}

--- a/src/services/generation-api.ts
+++ b/src/services/generation-api.ts
@@ -101,6 +101,7 @@ export async function generateTeacherPack(
         objectiveId: request.objectiveId,
         options: request.options,
         inspiration: request.inspiration,
+        designPackContext: request.designPackContext,
         aiProvider: request.aiProvider || "premium",
         aiModel: request.aiModel,
         prePolished: request.prePolished,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,7 @@ export type {
   ImageStats,
   ProjectOptions,
   InspirationItem,
+  DesignPackContext,
   GenerationProgress,
   GenerationResult,
   EstimateRequest,
@@ -32,6 +33,7 @@ export { DEFAULT_VISUAL_SETTINGS } from "@shared/types";
 import type {
   ProjectOptions,
   InspirationItem,
+  DesignPackContext,
   LessonMetadata,
   GenerationMode,
   VisualSettings,
@@ -90,6 +92,7 @@ export interface GenerationRequest {
   options: ProjectOptions;
   inspiration: InspirationItem[];
   objectiveId?: string | null;
+  designPackContext?: DesignPackContext;
   aiProvider?: "premium" | "local" | "claude" | "openai" | "ollama";
   aiModel?: string;
   prePolished?: boolean;


### PR DESCRIPTION
## Summary
- add deterministic merge utilities for ad-hoc inspiration + selected design-pack items
- include merged inspiration and explicit `designPackContext` in generation requests
- show design-pack context in prompt review and extend backend route to merge/pass context

## Testing
- `npm run test:run -- src/__tests__/lib/inspiration-merge.test.ts src/__tests__/components/wizard/GenerationStep.test.tsx src/__tests__/components/wizard/PromptReviewStep.test.tsx src/__tests__/services/generation-api.test.ts`
- `cd generation-api && npm run test:run -- src/__tests__/routes/generate.test.ts`

Closes #33
