### PR TITLE
Issue #31: Deploy Generation API to Cloud Run (staging/prod)

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,273 @@
+name: Deploy Generation API (Cloud Run)
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Deploy target"
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+          - both
+        default: staging
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy-staging:
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+      (github.event_name == 'workflow_dispatch' && (inputs.environment == 'staging' || inputs.environment == 'both'))
+    runs-on: ubuntu-latest
+    environment: staging
+    env:
+      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      GCP_REGION: ${{ secrets.GCP_REGION }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      CLOUD_RUN_SERVICE: ${{ secrets.CLOUD_RUN_SERVICE }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+      STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+      STRIPE_MODE: ${{ secrets.STRIPE_MODE }}
+      APP_URL: ${{ secrets.APP_URL }}
+      PIXABAY_API_KEY: ${{ secrets.PIXABAY_API_KEY }}
+      SMOKE_TEST_AUTH_TOKEN: ${{ secrets.SMOKE_TEST_AUTH_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate required secrets
+        run: |
+          missing=0
+          for key in \
+            GCP_PROJECT_ID \
+            GCP_REGION \
+            GCP_WORKLOAD_IDENTITY_PROVIDER \
+            GCP_SERVICE_ACCOUNT \
+            CLOUD_RUN_SERVICE \
+            SUPABASE_URL \
+            SUPABASE_ANON_KEY \
+            SUPABASE_SERVICE_ROLE_KEY \
+            OPENAI_API_KEY \
+            STRIPE_SECRET_KEY \
+            STRIPE_WEBHOOK_SECRET \
+            STRIPE_MODE \
+            APP_URL \
+            PIXABAY_API_KEY \
+            SMOKE_TEST_AUTH_TOKEN
+          do
+            if [ -z "${!key}" ]; then
+              echo "Missing required secret: ${key}"
+              missing=1
+            fi
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Build container image
+        run: |
+          IMAGE_URI="gcr.io/${GCP_PROJECT_ID}/${CLOUD_RUN_SERVICE}:${GITHUB_SHA}"
+          gcloud builds submit generation-api \
+            --tag "${IMAGE_URI}" \
+            --project "${GCP_PROJECT_ID}"
+          echo "IMAGE_URI=${IMAGE_URI}" >> "$GITHUB_ENV"
+
+      - name: Deploy to Cloud Run (staging)
+        id: deploy
+        run: |
+          cat > cloudrun.env <<EOF
+          NODE_ENV=production
+          SUPABASE_URL=${SUPABASE_URL}
+          SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
+          SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
+          OPENAI_API_KEY=${OPENAI_API_KEY}
+          STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
+          STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
+          STRIPE_MODE=${STRIPE_MODE}
+          APP_URL=${APP_URL}
+          PIXABAY_API_KEY=${PIXABAY_API_KEY}
+          OLLAMA_AUTO_PULL=false
+          OLLAMA_WARMUP_TIMEOUT_MS=5000
+          EOF
+
+          DEPLOY_URL="$(
+            gcloud run deploy "${CLOUD_RUN_SERVICE}" \
+              --image "${IMAGE_URI}" \
+              --project "${GCP_PROJECT_ID}" \
+              --region "${GCP_REGION}" \
+              --platform managed \
+              --allow-unauthenticated \
+              --port 8080 \
+              --env-vars-file cloudrun.env \
+              --quiet \
+              --format='value(status.url)'
+          )"
+
+          echo "deploy_url=${DEPLOY_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node for smoke test
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run staging smoke test (/health + /estimate)
+        run: |
+          API_BASE_URL="${{ steps.deploy.outputs.deploy_url }}" \
+          API_BEARER_TOKEN="${SMOKE_TEST_AUTH_TOKEN}" \
+          SMOKE_LABEL="staging" \
+          node scripts/smoke-api.cjs
+
+      - name: Run staging Playwright API smoke (optional)
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+          PLAYWRIGHT_SKIP_WEBSERVER=1 \
+          STAGING_API_URL="${{ steps.deploy.outputs.deploy_url }}" \
+          STAGING_API_TOKEN="${SMOKE_TEST_AUTH_TOKEN}" \
+          npx playwright test e2e/staging-api-smoke.spec.ts --project=chromium
+
+  deploy-production:
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'workflow_dispatch' && (inputs.environment == 'production' || inputs.environment == 'both'))
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      GCP_REGION: ${{ secrets.GCP_REGION }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      CLOUD_RUN_SERVICE: ${{ secrets.CLOUD_RUN_SERVICE }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+      STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+      STRIPE_MODE: ${{ secrets.STRIPE_MODE }}
+      APP_URL: ${{ secrets.APP_URL }}
+      PIXABAY_API_KEY: ${{ secrets.PIXABAY_API_KEY }}
+      SMOKE_TEST_AUTH_TOKEN: ${{ secrets.SMOKE_TEST_AUTH_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate required secrets
+        run: |
+          missing=0
+          for key in \
+            GCP_PROJECT_ID \
+            GCP_REGION \
+            GCP_WORKLOAD_IDENTITY_PROVIDER \
+            GCP_SERVICE_ACCOUNT \
+            CLOUD_RUN_SERVICE \
+            SUPABASE_URL \
+            SUPABASE_ANON_KEY \
+            SUPABASE_SERVICE_ROLE_KEY \
+            OPENAI_API_KEY \
+            STRIPE_SECRET_KEY \
+            STRIPE_WEBHOOK_SECRET \
+            STRIPE_MODE \
+            APP_URL \
+            PIXABAY_API_KEY \
+            SMOKE_TEST_AUTH_TOKEN
+          do
+            if [ -z "${!key}" ]; then
+              echo "Missing required secret: ${key}"
+              missing=1
+            fi
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Build container image
+        run: |
+          IMAGE_URI="gcr.io/${GCP_PROJECT_ID}/${CLOUD_RUN_SERVICE}:${GITHUB_SHA}"
+          gcloud builds submit generation-api \
+            --tag "${IMAGE_URI}" \
+            --project "${GCP_PROJECT_ID}"
+          echo "IMAGE_URI=${IMAGE_URI}" >> "$GITHUB_ENV"
+
+      - name: Deploy to Cloud Run (production)
+        id: deploy
+        run: |
+          cat > cloudrun.env <<EOF
+          NODE_ENV=production
+          SUPABASE_URL=${SUPABASE_URL}
+          SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
+          SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
+          OPENAI_API_KEY=${OPENAI_API_KEY}
+          STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
+          STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
+          STRIPE_MODE=${STRIPE_MODE}
+          APP_URL=${APP_URL}
+          PIXABAY_API_KEY=${PIXABAY_API_KEY}
+          OLLAMA_AUTO_PULL=false
+          OLLAMA_WARMUP_TIMEOUT_MS=5000
+          EOF
+
+          DEPLOY_URL="$(
+            gcloud run deploy "${CLOUD_RUN_SERVICE}" \
+              --image "${IMAGE_URI}" \
+              --project "${GCP_PROJECT_ID}" \
+              --region "${GCP_REGION}" \
+              --platform managed \
+              --allow-unauthenticated \
+              --port 8080 \
+              --env-vars-file cloudrun.env \
+              --quiet \
+              --format='value(status.url)'
+          )"
+
+          echo "deploy_url=${DEPLOY_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node for smoke test
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run production smoke test (/health + /estimate)
+        run: |
+          API_BASE_URL="${{ steps.deploy.outputs.deploy_url }}" \
+          API_BEARER_TOKEN="${SMOKE_TEST_AUTH_TOKEN}" \
+          SMOKE_LABEL="production" \
+          node scripts/smoke-api.cjs

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Health endpoint (`generation-api`) includes local readiness fields:
 - A local dev override exists in runtime settings for development only and should remain disabled for teacher distributions.
 - CI and release workflows run `npm run scan:artifact-secrets` against built artifacts to catch leaked key patterns before shipping.
 - Detailed policy/runbook: `docs/security/no-keys-on-teacher-machines.md`.
+- Cloud Run deploy runbook: `docs/ops/cloud-run-deploy.md`.
 - Stripe staging/live setup runbook: `docs/ops/stripe-environments.md`.
 - Clean-machine QA checklist: `docs/qa/clean-machine.md`.
 - Inspiration/design-pack storage ADR: `docs/architecture/adr-0001-local-first-inspiration.md`.

--- a/docs/ops/cloud-run-deploy.md
+++ b/docs/ops/cloud-run-deploy.md
@@ -1,0 +1,92 @@
+# Cloud Run Deployment Runbook (Generation API)
+
+## Goal
+
+Deploy `generation-api` to hosted HTTPS endpoints for `staging` and `production` with repeatable workflow automation and smoke verification.
+
+## Workflow
+
+- Workflow file: `.github/workflows/deploy-api.yml`
+- Trigger modes:
+  - Push to `master`: deploys `staging`.
+  - Push tag `v*`: deploys `production`.
+  - Manual dispatch: deploy `staging`, `production`, or `both`.
+
+## Required GitHub Environment Setup
+
+Create two GitHub environments:
+
+- `staging`
+- `production`
+
+Add these secrets in each environment:
+
+- `GCP_PROJECT_ID`
+- `GCP_REGION`
+- `GCP_WORKLOAD_IDENTITY_PROVIDER`
+- `GCP_SERVICE_ACCOUNT`
+- `CLOUD_RUN_SERVICE`
+- `SUPABASE_URL`
+- `SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `OPENAI_API_KEY`
+- `STRIPE_SECRET_KEY`
+- `STRIPE_WEBHOOK_SECRET`
+- `STRIPE_MODE`
+- `APP_URL`
+- `PIXABAY_API_KEY`
+- `SMOKE_TEST_AUTH_TOKEN` (valid Supabase auth token for `/estimate` smoke)
+
+## Container Image
+
+- Dockerfile: `generation-api/Dockerfile`
+- Base image: Playwright runtime image (Chromium included), so PDF/inspiration parsing paths work in Cloud Run.
+- Runtime defaults for Cloud Run:
+  - `NODE_ENV=production`
+  - `PORT=8080`
+  - `OLLAMA_AUTO_PULL=false`
+  - `OLLAMA_WARMUP_TIMEOUT_MS=5000`
+
+## Deployment Validation
+
+The workflow deploy job runs:
+
+1. `scripts/smoke-api.cjs` against deployed URL:
+   - `GET /health`
+   - Authenticated `POST /estimate`
+2. Staging-only Playwright smoke:
+   - `e2e/staging-api-smoke.spec.ts`
+   - Guarded by staging URL/token env vars set in workflow.
+
+## Manual Smoke Commands
+
+```bash
+# Scripted smoke
+API_BASE_URL="https://<cloud-run-url>" \
+API_BEARER_TOKEN="<supabase-jwt>" \
+node scripts/smoke-api.cjs
+```
+
+```bash
+# Playwright smoke (API only, no local web server)
+PLAYWRIGHT_SKIP_WEBSERVER=1 \
+STAGING_API_URL="https://<cloud-run-url>" \
+STAGING_API_TOKEN="<supabase-jwt>" \
+npx playwright test e2e/staging-api-smoke.spec.ts --project=chromium
+```
+
+## Desktop Runtime Endpoint Selection
+
+Desktop endpoint switching is runtime-configurable and does not require rebuilds:
+
+- Settings dialog endpoint presets/custom URL (`#32` implementation).
+- Verify endpoint choice in diagnostics before premium generation checks.
+
+## Rollback
+
+If a deploy fails smoke checks or production quality gates:
+
+1. Open Cloud Run revision history for the service.
+2. Route traffic back to prior healthy revision.
+3. Re-run smoke checks against restored revision URL.
+4. Leave issue/PR note with failed revision SHA and rollback timestamp.

--- a/e2e/staging-api-smoke.spec.ts
+++ b/e2e/staging-api-smoke.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+
+const stagingApiUrl = process.env.STAGING_API_URL;
+const stagingApiToken = process.env.STAGING_API_TOKEN;
+
+test.describe("Staging API smoke", () => {
+  test("health and estimate endpoints respond correctly", async ({ request }) => {
+    test.skip(
+      !stagingApiUrl || !stagingApiToken,
+      "Set STAGING_API_URL and STAGING_API_TOKEN to run staging smoke."
+    );
+
+    const healthResponse = await request.get(new URL("/health", stagingApiUrl).toString());
+    expect(healthResponse.ok()).toBe(true);
+    const healthPayload = await healthResponse.json();
+    expect(healthPayload.status).toBe("ok");
+
+    const estimateResponse = await request.post(new URL("/estimate", stagingApiUrl).toString(), {
+      headers: {
+        Authorization: `Bearer ${stagingApiToken}`,
+      },
+      data: {
+        grade: "3",
+        subject: "math",
+        options: {
+          format: "worksheet",
+          questionCount: 5,
+          includeAnswerKey: true,
+        },
+        visualSettings: {
+          includeVisuals: false,
+        },
+        generationMode: "standard",
+      },
+    });
+
+    expect(estimateResponse.ok()).toBe(true);
+    const estimatePayload = await estimateResponse.json();
+    expect(typeof estimatePayload?.estimate?.expectedCredits).toBe("number");
+    expect(estimatePayload.estimate.expectedCredits).toBeGreaterThan(0);
+  });
+});

--- a/generation-api/.dockerignore
+++ b/generation-api/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+coverage
+*.log
+.env
+.env.*
+!.env.example
+src/__tests__

--- a/generation-api/.env.example
+++ b/generation-api/.env.example
@@ -16,6 +16,9 @@ PREMIUM_AI_PROVIDER=openai
 # Premium provider (requires API key)
 OPENAI_API_KEY=your-openai-api-key
 
+# Stock images for worksheet visuals
+PIXABAY_API_KEY=your-pixabay-api-key
+
 # Stripe Checkout (required for credit purchases)
 # STRIPE_MODE must match key prefix:
 # - test => sk_test_...
@@ -31,4 +34,7 @@ APP_URL=http://localhost:1420
 # Install: https://ollama.com/download
 # Then run: ollama pull llama3.2 && ollama serve
 OLLAMA_BASE_URL=http://localhost:11434
-OLLAMA_MODEL=llama3.2
+OLLAMA_PRIMARY_MODEL=llama3.1:8b
+OLLAMA_FALLBACK_MODELS=qwen2.5:7b,gemma3:4b,llama3.2
+OLLAMA_AUTO_PULL=true
+OLLAMA_WARMUP_TIMEOUT_MS=180000

--- a/generation-api/Dockerfile
+++ b/generation-api/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+FROM mcr.microsoft.com/playwright:v1.58.0-jammy
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src ./src
+COPY verify-content.cjs ./verify-content.cjs
+
+RUN npm run build \
+  && npm prune --omit=dev \
+  && chown -R pwuser:pwuser /app
+
+ENV NODE_ENV=production
+ENV PORT=8080
+ENV OLLAMA_AUTO_PULL=false
+ENV OLLAMA_WARMUP_TIMEOUT_MS=5000
+
+EXPOSE 8080
+
+USER pwuser
+
+CMD ["node", "dist/index.js"]

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report e2e-report",
+    "smoke:api": "node scripts/smoke-api.cjs",
     "bench:ollama": "node scripts/benchmark-ollama-models.cjs",
     "scan:artifact-secrets": "node scripts/scan-artifact-secrets.cjs dist src-tauri/target/release/bundle"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const useWebServer = process.env.PLAYWRIGHT_SKIP_WEBSERVER !== "1";
+
 /**
  * Playwright E2E Test Configuration for TA (Teacher's Assistant)
  * @see https://playwright.dev/docs/test-configuration
@@ -79,10 +81,12 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  webServer: {
-    command: "npm run dev",
-    url: "http://localhost:1420",
-    reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
-  },
+  webServer: useWebServer
+    ? {
+        command: "npm run dev",
+        url: "http://localhost:1420",
+        reuseExistingServer: !process.env.CI,
+        timeout: 120 * 1000,
+      }
+    : undefined,
 });

--- a/scripts/smoke-api.cjs
+++ b/scripts/smoke-api.cjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+const apiBaseUrl = process.env.API_BASE_URL;
+const apiBearerToken = process.env.API_BEARER_TOKEN;
+const smokeLabel = process.env.SMOKE_LABEL || "cloud-run";
+const requireAuthSmoke = process.env.REQUIRE_AUTH_SMOKE !== "false";
+
+function fail(message) {
+  console.error(`[smoke-api] ${message}`);
+  process.exit(1);
+}
+
+function toUrl(pathname) {
+  return new URL(pathname, apiBaseUrl).toString();
+}
+
+async function run() {
+  if (!apiBaseUrl) {
+    fail("Missing API_BASE_URL.");
+  }
+
+  console.log(`[smoke-api] Running ${smokeLabel} smoke checks against ${apiBaseUrl}`);
+
+  const healthResponse = await fetch(toUrl("/health"));
+  if (!healthResponse.ok) {
+    fail(`/health failed with status ${healthResponse.status}.`);
+  }
+
+  const healthBody = await healthResponse.json();
+  if (healthBody.status !== "ok") {
+    fail(`/health returned unexpected payload: ${JSON.stringify(healthBody)}`);
+  }
+
+  console.log("[smoke-api] /health passed");
+
+  if (!apiBearerToken) {
+    if (requireAuthSmoke) {
+      fail("Missing API_BEARER_TOKEN for authenticated /estimate smoke.");
+    }
+
+    console.log("[smoke-api] Skipping /estimate because API_BEARER_TOKEN is missing.");
+    return;
+  }
+
+  const estimateResponse = await fetch(toUrl("/estimate"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiBearerToken}`,
+    },
+    body: JSON.stringify({
+      grade: "3",
+      subject: "math",
+      options: {
+        format: "worksheet",
+        questionCount: 5,
+        includeAnswerKey: true,
+      },
+      visualSettings: {
+        includeVisuals: false,
+      },
+      generationMode: "standard",
+    }),
+  });
+
+  if (!estimateResponse.ok) {
+    const bodyText = await estimateResponse.text();
+    fail(`/estimate failed with status ${estimateResponse.status}: ${bodyText}`);
+  }
+
+  const estimateBody = await estimateResponse.json();
+  if (
+    !estimateBody?.estimate ||
+    typeof estimateBody.estimate.expectedCredits !== "number"
+  ) {
+    fail(`/estimate returned unexpected payload: ${JSON.stringify(estimateBody)}`);
+  }
+
+  console.log(
+    `[smoke-api] /estimate passed (expectedCredits=${estimateBody.estimate.expectedCredits})`
+  );
+  console.log("[smoke-api] Smoke checks passed.");
+}
+
+run().catch((error) => {
+  fail(error instanceof Error ? error.message : String(error));
+});


### PR DESCRIPTION
## Summary
- add Cloud Run Dockerfile for `generation-api`
- add GitHub Actions deploy workflow for staging/prod with OIDC auth
- add automated smoke verification (`/health` + authenticated `/estimate`)
- add env-guarded Playwright staging API smoke test and API-only mode
- add Cloud Run runbook and update docs/env examples

## Testing
- `API_BASE_URL=http://localhost:3001 REQUIRE_AUTH_SMOKE=false npm run smoke:api`
- `PLAYWRIGHT_SKIP_WEBSERVER=1 npm run test:e2e -- e2e/staging-api-smoke.spec.ts --project=chromium`

Closes #31
